### PR TITLE
Add detection labels and simple web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ Este projeto cria uma camada de proteção inteligente para o proxy [Nginx Unit]
 2. Execute `docker-compose up --build` para iniciar tudo.
 3. Utilize o menu interativo para ativar ou desativar a proteção e selecionar a interface de rede.
 
-A aplicação realiza análise semântica e detecção de anomalias nos logs. Caso variáveis de banco estejam configuradas, os resultados são armazenados no PostgreSQL informado.
+A aplicação realiza análise semântica e detecção de anomalias nos logs. Caso variáveis de banco estejam configuradas, os resultados são armazenados no PostgreSQL informado.\
+Um painel web simples está disponível em `http://localhost:8080/logs` para visualizar os logs registrados.

--- a/app/main.py
+++ b/app/main.py
@@ -6,9 +6,17 @@ from .detection import Detector
 def packet_callback(packet):
     if packet.haslayer('Raw'):
         payload = bytes(packet['Raw'].load).decode('latin-1', errors='ignore')
-        anomaly, severity, nids = detector.analyze(payload)
-        db.save_log(config.NETWORK_INTERFACE, payload, severity, anomaly)
-        print(f"Anomaly: {anomaly} Severity: {severity} NIDS: {nids}")
+        result = detector.analyze(payload)
+        db.save_log(
+            config.NETWORK_INTERFACE,
+            payload,
+            result['severity'],
+            result['anomaly'],
+            result['nids'],
+        )
+        print(
+            f"Anomaly: {result['anomaly']['label']} Severity: {result['severity']['label']} NIDS: {result['nids']['label']}"
+        )
 
 def run():
     db.init_db()

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Logs</title>
+    <style>
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 4px; }
+        th { background: #eee; }
+    </style>
+</head>
+<body>
+    <h1>Logs</h1>
+    <table>
+        <tr>
+            <th>Timestamp</th>
+            <th>Interface</th>
+            <th>Log</th>
+            <th>Severity</th>
+            <th>Anomaly</th>
+            <th>Category</th>
+        </tr>
+        {% for log in logs %}
+        <tr>
+            <td>{{ log.created_at }}</td>
+            <td>{{ log.iface }}</td>
+            <td>{{ log.log }}</td>
+            <td>{{ log.severity.label }}</td>
+            <td>{{ log.anomaly.label }}</td>
+            <td>{{ log.nids.label }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1,5 +1,17 @@
-from http import HTTPStatus
+from flask import Flask, render_template
+from . import db
 
-def application(environ, start_response):
-    start_response('200 OK', [('Content-Type', 'text/plain')])
-    return [b'Nginx Unit running']
+app = Flask(__name__)
+
+db.init_db()
+
+@app.route('/')
+def index():
+    return 'Nginx Unit running'
+
+@app.route('/logs')
+def logs():
+    logs = db.get_logs(limit=200)
+    return render_template('logs.html', logs=logs)
+
+application = app

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ psycopg2-binary
 transformers
 scapy
 python-dotenv
+flask

--- a/schema.sql
+++ b/schema.sql
@@ -4,5 +4,6 @@ CREATE TABLE IF NOT EXISTS logs (
     iface TEXT NOT NULL,
     log TEXT NOT NULL,
     severity JSONB,
-    anomaly JSONB
+    anomaly JSONB,
+    nids JSONB
 );


### PR DESCRIPTION
## Summary
- extend detection to return category labels
- log severity, anomaly and NIDS results to database
- expose stored logs through a new Flask-based dashboard
- include basic HTML template and documentation note

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68683e5fc03c832aa88345e3fe542b23