### PR TITLE
Fix db init when running outside container

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import psycopg2
 from psycopg2.extras import RealDictCursor, Json
 from . import config
@@ -13,11 +16,14 @@ if config.POSTGRES_HOST:
     )
     conn.autocommit = True
 
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schema.sql"
+
+
 def init_db():
     if conn is None:
         return
     with conn.cursor() as cur:
-        with open('/app/schema.sql') as f:
+        with open(SCHEMA_PATH) as f:
             cur.execute(f.read())
 
 


### PR DESCRIPTION
## Summary
- resolve path to `schema.sql` dynamically so scripts work locally and in containers

## Testing
- `pip install -r requirements.txt`
- `python3 -m app.menu` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686843e2d8b0832a8829ac068696e277