### PR TITLE
Add pentest structure check

### DIFF
--- a/pentest/README.md
+++ b/pentest/README.md
@@ -1,0 +1,13 @@
+# Pentest
+
+Esta pasta contém utilidades para verificar a estrutura do projeto.
+
+## Teste de estrutura
+
+Execute o script `test_structure.py` para checar se todos os arquivos essenciais estão presentes:
+
+```bash
+python pentest/test_structure.py
+```
+
+O comando retorna uma lista de itens ausentes ou uma mensagem de sucesso.

--- a/pentest/test_structure.py
+++ b/pentest/test_structure.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Verifica se a estrutura essencial do projeto está presente."""
+import os
+import sys
+
+REQUIRED_PATHS = [
+    'Dockerfile',
+    'docker-compose.yml',
+    'entrypoint.sh',
+    'requirements.txt',
+    'schema.sql',
+    'unit-config.json',
+    'README.md',
+    os.path.join('app', 'config.py'),
+    os.path.join('app', 'db.py'),
+    os.path.join('app', 'detection.py'),
+    os.path.join('app', 'main.py'),
+    os.path.join('app', 'menu.py'),
+    os.path.join('app', 'wsgi.py'),
+    os.path.join('app', 'templates'),
+]
+
+def check_structure(base_dir: str) -> list:
+    """Retorna uma lista de caminhos que não existem."""
+    missing = []
+    for path in REQUIRED_PATHS:
+        if not os.path.exists(os.path.join(base_dir, path)):
+            missing.append(path)
+    return missing
+
+
+def main() -> None:
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    missing = check_structure(base_dir)
+    if missing:
+        print('Estrutura inválida! Os seguintes itens estão ausentes:')
+        for path in missing:
+            print(f'- {path}')
+        sys.exit(1)
+    print('Estrutura verificada com sucesso.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `pentest` folder with a script to verify project structure
- document how to run the structure test

## Testing
- `python pentest/test_structure.py`
- `python -m py_compile pentest/test_structure.py`


------
https://chatgpt.com/codex/tasks/task_e_68685c588f3c832ab91b6a3cb56a3d81