### PR TITLE
Add sidebar layout to web UI

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="pt-br" data-bs-theme="light">
+<head>
+    <meta charset="utf-8">
+    <title>{{ title or "Nginx Unit IA" }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body { overflow-x: hidden; }
+        #sidebar {
+            position: fixed;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            width: 200px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+        #content {
+            margin-left: 220px;
+            padding: 1rem;
+        }
+        .severity-high { color: #dc3545; }
+        .severity-medium { color: #fd7e14; }
+        .severity-low { color: #198754; }
+        .status-blocked { color: #dc3545; }
+        .status-unblocked { color: #198754; }
+    </style>
+</head>
+<body>
+    <div id="sidebar">
+        <h4>Nginx Unit IA</h4>
+        <ul class="nav flex-column mb-3">
+            <li class="nav-item"><a href="/logs" class="nav-link">Logs</a></li>
+            <li class="nav-item"><a href="/blocked" class="nav-link">IPs Bloqueados</a></li>
+        </ul>
+        <button id="toggle-btn" class="btn btn-secondary w-100">Alternar tema</button>
+    </div>
+    <div id="content">
+        {% block content %}{% endblock %}
+    </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+function toggleTheme(){
+    const html=document.documentElement;
+    const theme=html.getAttribute('data-bs-theme');
+    html.setAttribute('data-bs-theme', theme==='dark'?'light':'dark');
+}
+document.getElementById('toggle-btn').addEventListener('click', toggleTheme);
+</script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/app/templates/blocked.html
+++ b/app/templates/blocked.html
@@ -1,31 +1,23 @@
-<!doctype html>
-<html lang="pt-br" data-bs-theme="light">
-<head>
-    <meta charset="utf-8">
-    <title>IPs Bloqueados</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="p-4">
-    <div class="container">
-        <div class="d-flex justify-content-between align-items-center mb-3">
-            <h1 class="h3 mb-0">IPs Bloqueados</h1>
-            <button id="toggle-btn" class="btn btn-secondary">Alternar tema</button>
-        </div>
-        <div class="table-responsive">
-            <table class="table table-sm table-bordered" id="blocked-table">
-                <thead class="table-light">
-                    <tr>
-                        <th>IP</th>
-                        <th>Status</th>
-                        <th>Motivo</th>
-                        <th>Data/Hora</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
-        </div>
-    </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+{% extends 'base.html' %}
+
+{% block content %}
+<h1 class="h3 mb-3">IPs Bloqueados</h1>
+<div class="table-responsive">
+    <table class="table table-sm table-bordered" id="blocked-table">
+        <thead class="table-light">
+            <tr>
+                <th>IP</th>
+                <th>Status</th>
+                <th>Motivo</th>
+                <th>Data/Hora</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+{% endblock %}
+
+{% block scripts %}
 <script>
 async function fetchBlocked() {
     const res = await fetch('/api/blocked');
@@ -34,22 +26,16 @@ async function fetchBlocked() {
     tbody.innerHTML = '';
     data.forEach(item => {
         const tr = document.createElement('tr');
+        const statusClass = item.status === 'blocked' ? 'status-blocked' : 'status-unblocked';
         tr.innerHTML = `
             <td>${item.ip}</td>
-            <td>${item.status}</td>
+            <td class="${statusClass}">${item.status}</td>
             <td>${item.reason || ''}</td>
             <td>${item.blocked_at}</td>`;
         tbody.appendChild(tr);
     });
 }
-function toggleTheme() {
-    const html = document.documentElement;
-    const theme = html.getAttribute('data-bs-theme');
-    html.setAttribute('data-bs-theme', theme === 'dark' ? 'light' : 'dark');
-}
-document.getElementById('toggle-btn').addEventListener('click', toggleTheme);
 fetchBlocked();
 setInterval(fetchBlocked, 5000);
 </script>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -1,41 +1,25 @@
-<!doctype html>
-<html lang="pt-br" data-bs-theme="light">
-<head>
-    <meta charset="utf-8">
-    <title>Logs</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-        .severity-high { color: #dc3545; }
-        .severity-medium { color: #fd7e14; }
-        .severity-low { color: #198754; }
-    </style>
-</head>
-<body class="p-4">
-    <div class="container">
-        <div class="d-flex justify-content-between align-items-center mb-3">
-            <h1 class="h3 mb-0">Logs</h1>
-            <div>
-                <a href="/blocked" class="btn btn-primary me-2">IPs Bloqueados</a>
-                <button id="toggle-btn" class="btn btn-secondary">Alternar tema</button>
-            </div>
-        </div>
-        <div class="table-responsive">
-            <table class="table table-sm table-bordered" id="logs-table">
-                <thead class="table-light">
-                <tr>
-                    <th>Timestamp</th>
-                    <th>Interface</th>
-                    <th>Log</th>
-                    <th>Severity</th>
-                    <th>Anomaly</th>
-                    <th>Category</th>
-                </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
-        </div>
-    </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+{% extends 'base.html' %}
+
+{% block content %}
+<h1 class="h3 mb-3">Logs</h1>
+<div class="table-responsive">
+    <table class="table table-sm table-bordered" id="logs-table">
+        <thead class="table-light">
+            <tr>
+                <th>Timestamp</th>
+                <th>Interface</th>
+                <th>Log</th>
+                <th>Severity</th>
+                <th>Anomaly</th>
+                <th>Category</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+{% endblock %}
+
+{% block scripts %}
 <script>
 async function fetchLogs() {
     const res = await fetch('/api/logs');
@@ -55,14 +39,7 @@ async function fetchLogs() {
         tbody.appendChild(tr);
     });
 }
-function toggleTheme() {
-    const html = document.documentElement;
-    const theme = html.getAttribute('data-bs-theme');
-    html.setAttribute('data-bs-theme', theme === 'dark' ? 'light' : 'dark');
-}
-document.getElementById('toggle-btn').addEventListener('click', toggleTheme);
 fetchLogs();
 setInterval(fetchLogs, 5000);
 </script>
-</body>
-</html>
+{% endblock %}

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -12,13 +12,13 @@ def index():
 @app.route('/logs')
 def logs():
     logs = db.get_logs(limit=200)
-    return render_template('logs.html', logs=logs)
+    return render_template('logs.html', title='Logs', logs=logs)
 
 
 @app.route('/blocked')
 def blocked():
     blocked = db.get_blocked_ips(limit=200)
-    return render_template('blocked.html', blocked=blocked)
+    return render_template('blocked.html', title='IPs Bloqueados', blocked=blocked)
 
 @app.route('/api/logs')
 def api_logs():


### PR DESCRIPTION
## Summary
- add new base template with fixed sidebar
- refactor logs and blocked templates to extend the base
- color code status on blocked IPs page
- pass page titles from Flask app

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686868c398f4832abafe16a0c02937bf