### PR TITLE
Add hello app proxied by Nginx Unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Este projeto cria uma camada de proteção inteligente para o proxy [Nginx Unit](https://unit.nginx.org/) utilizando modelos de linguagem do HuggingFace. Somente o Nginx Unit roda em container; os mecanismos de detecção, categorização e classificação devem ser executados fora do container.
 
 ## Estrutura
-- `docker-compose.yml` define apenas o serviço do proxy Nginx Unit. A aplicação de detecção deve ser executada fora dos containers.
+- `docker-compose.yml` define o serviço do proxy Nginx Unit e uma aplicação de teste "Hello World". A aplicação principal de detecção continua executando fora dos containers.
 - `Dockerfile` constroi a imagem para a aplicação, baixando os modelos necessários.
 - `app/` contém o código Python responsável pela detecção.
 - `schema.sql` contém a estrutura do banco de dados.
@@ -11,7 +11,7 @@ Este projeto cria uma camada de proteção inteligente para o proxy [Nginx Unit]
 
 ## Uso rápido
 1. Copie `.env.example` para `.env` e ajuste as variáveis.
-2. Execute `docker-compose up -d` para subir apenas o Nginx Unit.
+2. Execute `docker-compose up -d` para subir o Nginx Unit e a aplicação de teste.
 3. Em seguida, rode `python -m app.menu` fora dos containers para iniciar a proteção
    e o painel web. No menu é possível selecionar a interface de rede e o dispositivo
    de inferência.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,10 @@ services:
       - ./unit-config.json:/docker-entrypoint.d/unit-config.json
     ports:
       - "${UNIT_PORT:-8090}:8080"
+    depends_on:
+      - hello
+
+  hello:
+    build: ./hello_app
+    ports:
+      - "8000:8000"

--- a/hello_app/Dockerfile
+++ b/hello_app/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY hello.py .
+EXPOSE 8000
+CMD ["python", "hello.py"]

--- a/hello_app/hello.py
+++ b/hello_app/hello.py
@@ -1,0 +1,11 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(b'Hello World!!')
+
+if __name__ == '__main__':
+    HTTPServer(('', 8000), Handler).serve_forever()

--- a/unit-config.json
+++ b/unit-config.json
@@ -1,7 +1,7 @@
 {
     "listeners": {
         "*:8080": {
-            "pass": "applications/dummy"
+            "pass": "routes"
         }
     },
     "applications": {
@@ -10,5 +10,14 @@
             "path": "/www/app",
             "module": "wsgi"
         }
-    }
+    },
+    "routes": [
+        {
+            "match": { "uri": "/hello" },
+            "action": { "proxy": "http://hello:8000" }
+        },
+        {
+            "action": { "pass": "applications/dummy" }
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- add hello world sample container to docker-compose
- proxy requests at `/hello` to the sample container using Unit routes
- document the new service in README

## Testing
- `pytest -q`
- `python pentest/test_structure.py`


------
https://chatgpt.com/codex/tasks/task_e_686869f6f9ec832a94c28096a2984e7d