### PR TITLE
Sync DB with UFW state

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Um painel web dinâmico (iniciado opcionalmente pelo menu) fica disponível em `
 
 A detecção de ameaças também integra-se ao firewall **UFW**. Sempre que um ataque ou invasão é identificado, o IP de origem é automaticamente bloqueado via UFW e registrado no banco de dados.
 O painel web possui a página `http://localhost:8080/blocked` que exibe todos os IPs bloqueados, seu status, motivo e data/hora do bloqueio.
+Sempre que essa página é acessada, a lista é sincronizada com as regras atuais do UFW, garantindo que o banco reflita o estado real do firewall.

--- a/app/firewall.py
+++ b/app/firewall.py
@@ -1,4 +1,7 @@
+import re
 import subprocess
+
+from . import db
 
 
 def is_ip_blocked(ip: str) -> bool:
@@ -30,3 +33,56 @@ def block_ip(ip: str) -> bool:
     except Exception as exc:
         print(f"Erro ao bloquear IP {ip}: {exc}")
         return False
+
+
+def get_ufw_blocked_ips() -> set:
+    """Return the current set of blocked IPs from UFW rules."""
+    try:
+        result = subprocess.run(
+            ["sudo", "ufw", "status", "numbered"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except Exception as exc:
+        print(f"Erro ao obter IPs do UFW: {exc}")
+        return set()
+
+    ips = set()
+    for line in result.stdout.splitlines():
+        if "DENY" in line:
+            match = re.search(r"from\s+(\S+)", line)
+            if match:
+                ips.add(match.group(1))
+            else:
+                parts = line.split()
+                for part in parts:
+                    if re.match(r"\d+\.\d+\.\d+\.\d+", part):
+                        ips.add(part)
+                        break
+    return ips
+
+
+def sync_blocked_ips_with_ufw() -> set:
+    """Synchronize blocked IPs in the database with current UFW rules."""
+    ufw_ips = get_ufw_blocked_ips()
+    if db.conn is None:
+        return ufw_ips
+
+    with db.conn.cursor() as cur:
+        cur.execute("SELECT ip FROM blocked_ips WHERE status = 'blocked'")
+        current_blocked = {row[0] for row in cur.fetchall()}
+
+    # insert new blocked IPs
+    for ip in ufw_ips - current_blocked:
+        db.save_blocked_ip(ip, "ufw", "blocked")
+
+    # mark IPs no longer blocked
+    for ip in current_blocked - ufw_ips:
+        with db.conn.cursor() as cur:
+            cur.execute(
+                "UPDATE blocked_ips SET status='unblocked' WHERE ip=%s AND status='blocked'",
+                (ip,),
+            )
+
+    return ufw_ips

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1,5 +1,5 @@
 from flask import Flask, render_template, jsonify
-from . import db
+from . import db, firewall
 
 app = Flask(__name__)
 
@@ -17,6 +17,7 @@ def logs():
 
 @app.route('/blocked')
 def blocked():
+    firewall.sync_blocked_ips_with_ufw()
     blocked = db.get_blocked_ips(limit=200)
     return render_template('blocked.html', title='IPs Bloqueados', blocked=blocked)
 
@@ -39,6 +40,7 @@ def api_logs():
 
 @app.route('/api/blocked')
 def api_blocked():
+    firewall.sync_blocked_ips_with_ufw()
     blocked = db.get_blocked_ips(limit=200)
     serialized = [
         {


### PR DESCRIPTION
## Summary
- add helper to read blocked IPs from UFW
- sync database with real UFW rules
- refresh blocked list on every request
- mention the automatic sync in README

## Testing
- `python3 pentest/test_structure.py`


------
https://chatgpt.com/codex/tasks/task_e_68686c157b0c832a8154d7690831519f