### PR TITLE
Improve menu and panel features

### DIFF
--- a/app/detection.py
+++ b/app/detection.py
@@ -1,12 +1,13 @@
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 import torch
+import logging
 from . import config
 
 class Detector:
     def __init__(self):
         device = config.DEVICE
         if device == "cuda" and not torch.cuda.is_available():
-            print("CUDA n\u00e3o dispon\u00edvel, usando CPU")
+            logging.warning("CUDA n\u00e3o dispon\u00e9vel, usando CPU")
             device = "cpu"
         self.device = torch.device(device)
 

--- a/app/firewall.py
+++ b/app/firewall.py
@@ -1,5 +1,6 @@
 import re
 import subprocess
+import logging
 
 from . import db
 
@@ -31,7 +32,7 @@ def block_ip(ip: str) -> bool:
         )
         return True
     except Exception as exc:
-        print(f"Erro ao bloquear IP {ip}: {exc}")
+        logging.error("Erro ao bloquear IP %s: %s", ip, exc)
         return False
 
 
@@ -45,7 +46,7 @@ def get_ufw_blocked_ips() -> set:
             check=True,
         )
     except Exception as exc:
-        print(f"Erro ao obter IPs do UFW: {exc}")
+        logging.error("Erro ao obter IPs do UFW: %s", exc)
         return set()
 
     ips = set()

--- a/app/menu.py
+++ b/app/menu.py
@@ -22,8 +22,10 @@ def start_protection():
 def stop_protection():
     global protection_thread
     if protection_thread and protection_thread.is_alive():
-        # no simple way to stop sniff; rely on program exit
-        print('Pare o container para desativar.')
+        main.stop()
+        protection_thread.join()
+        protection_thread = None
+        print('Prote\u00e7\u00e3o desativada.')
     else:
         print('Prote\u00e7\u00e3o n\u00e3o estava ativa.')
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,39 +3,33 @@
 <head>
     <meta charset="utf-8">
     <title>{{ title or "Nginx Unit IA" }}</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/lux/bootstrap.min.css" rel="stylesheet">
     <style>
-        body { overflow-x: hidden; }
-        #sidebar {
-            position: fixed;
-            top: 0;
-            bottom: 0;
-            left: 0;
-            width: 200px;
-            padding: 1rem;
-            background-color: #f8f9fa;
-        }
-        #content {
-            margin-left: 220px;
-            padding: 1rem;
-        }
-        .severity-high { color: #dc3545; }
-        .severity-medium { color: #fd7e14; }
-        .severity-low { color: #198754; }
-        .status-blocked { color: #dc3545; }
-        .status-unblocked { color: #198754; }
+        body { padding-top: 56px; }
+        .severity-high { color: #dc3545; font-weight: bold; }
+        .severity-medium { color: #fd7e14; font-weight: bold; }
+        .severity-low { color: #198754; font-weight: bold; }
+        .status-blocked { color: #dc3545; font-weight: bold; }
+        .status-unblocked { color: #198754; font-weight: bold; }
     </style>
 </head>
 <body>
-    <div id="sidebar">
-        <h4>Nginx Unit IA</h4>
-        <ul class="nav flex-column mb-3">
-            <li class="nav-item"><a href="/logs" class="nav-link">Logs</a></li>
-            <li class="nav-item"><a href="/blocked" class="nav-link">IPs Bloqueados</a></li>
-        </ul>
-        <button id="toggle-btn" class="btn btn-secondary w-100">Alternar tema</button>
-    </div>
-    <div id="content">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="/logs">Nginx Unit IA</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                    <li class="nav-item"><a class="nav-link" href="/logs">Logs</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/blocked">IPs Bloqueados</a></li>
+                </ul>
+                <button id="toggle-btn" class="btn btn-outline-light">Alternar tema</button>
+            </div>
+        </div>
+    </nav>
+    <div class="container mt-4">
         {% block content %}{% endblock %}
     </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/app/templates/blocked.html
+++ b/app/templates/blocked.html
@@ -1,19 +1,23 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1 class="h3 mb-3">IPs Bloqueados</h1>
-<div class="table-responsive">
-    <table class="table table-sm table-bordered" id="blocked-table">
-        <thead class="table-light">
-            <tr>
-                <th>IP</th>
-                <th>Status</th>
-                <th>Motivo</th>
-                <th>Data/Hora</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+<h1 class="h3 mb-4">IPs Bloqueados</h1>
+<div class="card">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+        <table class="table table-sm table-striped table-bordered mb-0" id="blocked-table">
+            <thead class="table-light">
+                <tr>
+                    <th>IP</th>
+                    <th>Status</th>
+                    <th>Motivo</th>
+                    <th>Data/Hora</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+  </div>
 </div>
 {% endblock %}
 

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -1,21 +1,25 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1 class="h3 mb-3">Logs</h1>
-<div class="table-responsive">
-    <table class="table table-sm table-bordered" id="logs-table">
-        <thead class="table-light">
-            <tr>
-                <th>Timestamp</th>
-                <th>Interface</th>
-                <th>Log</th>
-                <th>Severity</th>
-                <th>Anomaly</th>
-                <th>Category</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+<h1 class="h3 mb-4">Logs</h1>
+<div class="card">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+        <table class="table table-sm table-striped table-bordered mb-0" id="logs-table">
+            <thead class="table-light">
+                <tr>
+                    <th>Timestamp</th>
+                    <th>Interface</th>
+                    <th>Log</th>
+                    <th>Severity</th>
+                    <th>Anomaly</th>
+                    <th>Category</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+</table>
+    </div>
+  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- add AsyncSniffer-based start/stop in `main.py`
- allow stopping protection from menu
- hide detection output in console using logging to file
- update base template to navbar layout using Bootswatch theme
- wrap log tables in cards for a polished look

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68686eac0dc0832aa8dab6839b14c456