### PR TITLE
Alinhar melhor títulos no painel web

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,7 +21,7 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <ul class="navbar-nav mx-auto mb-2 mb-lg-0">
                     <li class="nav-item"><a class="nav-link" href="/logs">Logs</a></li>
                     <li class="nav-item"><a class="nav-link" href="/blocked">IPs Bloqueados</a></li>
                 </ul>

--- a/app/templates/blocked.html
+++ b/app/templates/blocked.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1 class="h3 mb-4">IPs Bloqueados</h1>
+<h1 class="h3 mb-4 text-center">IPs Bloqueados</h1>
 <div class="card">
   <div class="card-body p-0">
     <div class="table-responsive">

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1 class="h3 mb-4">Logs</h1>
+<h1 class="h3 mb-4 text-center">Logs</h1>
 <div class="card">
   <div class="card-body p-0">
     <div class="table-responsive">


### PR DESCRIPTION
## Summary
- centralize navigation menu links
- centralize page titles "Logs" e "IPs Bloqueados"

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868704c6e5c832a92ffe0f4d7dc58a5