### PR TITLE
Handle generic anomaly labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Este projeto cria uma camada de proteção inteligente para o proxy [Nginx Unit]
 - `app/` contém o código Python responsável pela detecção.
 - `schema.sql` contém a estrutura do banco de dados.
 - `.env.example` é um modelo de configuração (copie para `.env`). Inclui a variável `DEVICE` que define o dispositivo padrão (CPU ou GPU) e `UNIT_PORT` para alterar a porta do proxy Nginx Unit.
+- Caso o modelo de detecção de anomalias retorne rótulos genéricos (`LABEL_0`, `LABEL_1`), o código mapeia automaticamente esses valores para `normal` e `anomaly`.
 
 ## Uso rápido
 1. Copie `.env.example` para `.env` e ajuste as variáveis.


### PR DESCRIPTION
## Summary
- map generic anomaly labels (`LABEL_0`, `LABEL_1`) to friendly names
- document anomaly label mapping in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: environment has no network access)*

------
https://chatgpt.com/codex/tasks/task_e_686875a75f0c832aa943981443643561