### PR TITLE
Fix model initialization

### DIFF
--- a/app/detection.py
+++ b/app/detection.py
@@ -17,8 +17,6 @@ class Detector:
             device = "cpu"
         self.device = torch.device(device)
 
-        self.semantic_tokenizer = AutoTokenizer.from_pretrained(config.SEMANTIC_MODEL)
-        self.semantic_model = AutoModelForSequenceClassification.from_pretrained(config.SEMANTIC_MODEL).to(self.device)
         self.severity_tokenizer = AutoTokenizer.from_pretrained(config.SEVERITY_MODEL)
         self.severity_model = AutoModelForSequenceClassification.from_pretrained(config.SEVERITY_MODEL).to(self.device)
         self.anomaly_tokenizer = AutoTokenizer.from_pretrained(config.ANOMALY_MODEL)


### PR DESCRIPTION
## Summary
- remove unused sentence-transformer model loading to prevent initialization warnings

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68687fbded84832a8cda132ee717f024