### PR TITLE
Fix interface name sanitization

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,15 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+def sanitize_ifname(iface: str) -> str:
+    """Return interface name without NULs or surrounding whitespace."""
+    if not isinstance(iface, str):
+        iface = str(iface)
+    # keep only portion before first NUL and strip spaces
+    iface = iface.split("\x00", 1)[0].strip()
+    return iface
+
 POSTGRES_USER = os.getenv('POSTGRES_USER')
 POSTGRES_PASSWORD = os.getenv('POSTGRES_PASSWORD')
 POSTGRES_DB = os.getenv('POSTGRES_DB')
@@ -14,6 +23,6 @@ SEVERITY_MODEL = os.getenv('SEVERITY_MODEL')
 ANOMALY_MODEL = os.getenv('ANOMALY_MODEL')
 NIDS_MODEL = os.getenv('NIDS_MODEL')
 
-NETWORK_INTERFACE = os.getenv('NETWORK_INTERFACE', 'eth0')
+NETWORK_INTERFACE = sanitize_ifname(os.getenv('NETWORK_INTERFACE', 'eth0'))
 DEVICE = os.getenv('DEVICE', 'cpu')
 WEB_PANEL_PORT = int(os.getenv('WEB_PANEL_PORT', '8080'))

--- a/app/main.py
+++ b/app/main.py
@@ -56,15 +56,19 @@ def run():
         detector = Detector()
     db.init_db()
     # Defensive sanitization in case the interface contains unexpected NULs
-    iface = config.NETWORK_INTERFACE.replace("\x00", "")
+    iface = config.sanitize_ifname(config.NETWORK_INTERFACE)
     logging.info("Monitorando interface %s...", iface)
-    sniffer = AsyncSniffer(
-        iface=iface,
-        prn=packet_callback,
-        store=False,
-    )
-    sniffer.start()
-    sniffer.join()
+    try:
+        sniffer = AsyncSniffer(
+            iface=iface,
+            prn=packet_callback,
+            store=False,
+        )
+        sniffer.start()
+        sniffer.join()
+    except Exception as exc:
+        logging.error("Falha ao iniciar sniffer: %s", exc)
+        print(f"Erro ao iniciar captura: {exc}")
 
 
 def stop():

--- a/app/menu.py
+++ b/app/menu.py
@@ -81,7 +81,7 @@ def select_device():
 
 
 def select_interface():
-    interfaces = get_if_list()
+    interfaces = [config.sanitize_ifname(iface) for iface in get_if_list()]
     print("\nInterfaces dispon\u00edveis:")
     for idx, iface in enumerate(interfaces, 1):
         print(f"{idx}. {iface}")
@@ -93,9 +93,7 @@ def select_interface():
         if protection_thread and protection_thread.is_alive():
             print("Pare a prote\u00e7\u00e3o antes de mudar a interface.")
             return
-        selected = interfaces[idx]
-        # Remove any NUL characters that could break socket binding
-        selected = selected.replace("\x00", "")
+        selected = config.sanitize_ifname(interfaces[idx])
         config.NETWORK_INTERFACE = selected
         print(f"Interface selecionada: {config.NETWORK_INTERFACE}")
     except ValueError:


### PR DESCRIPTION
## Summary
- sanitize interface names at config load time
- ensure menu uses sanitized names
- guard `AsyncSniffer` startup with a try/except

## Testing
- `python pentest/test_structure.py`


------
https://chatgpt.com/codex/tasks/task_e_6868819f2020832a878bb7c4d7b1576c