### PR TITLE
Improve interface name sanitization

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,8 +8,8 @@ def sanitize_ifname(iface: str) -> str:
     """Return interface name without NULs or surrounding whitespace."""
     if not isinstance(iface, str):
         iface = str(iface)
-    # keep only portion before first NUL and strip spaces
-    iface = iface.split("\x00", 1)[0].strip()
+    # remove any NUL characters and surrounding whitespace
+    iface = iface.replace("\x00", "").strip()
     return iface
 
 POSTGRES_USER = os.getenv('POSTGRES_USER')


### PR DESCRIPTION
## Summary
- ensure interface names strip all NUL characters before use

## Testing
- `python3 pentest/test_structure.py`
- `python3 pentest/test_security.py` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_68688317ff88832ab2fa462e323a5943