### PR TITLE
Handle malformed network interface names

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -5,12 +5,12 @@ load_dotenv()
 
 
 def sanitize_ifname(iface: str) -> str:
-    """Return interface name without NULs or surrounding whitespace."""
+    """Return interface name without NUL bytes or surrounding whitespace."""
     if not isinstance(iface, str):
         iface = str(iface)
-    # remove any NUL characters and surrounding whitespace
-    iface = iface.replace("\x00", "").strip()
-    return iface
+    # split at first NUL in case the string contains embedded characters
+    iface = iface.split("\x00", 1)[0]
+    return iface.strip()
 
 POSTGRES_USER = os.getenv('POSTGRES_USER')
 POSTGRES_PASSWORD = os.getenv('POSTGRES_PASSWORD')

--- a/app/main.py
+++ b/app/main.py
@@ -55,8 +55,11 @@ def run():
     if detector is None:
         detector = Detector()
     db.init_db()
-    # Defensive sanitization in case the interface contains unexpected NULs
+    # Defensive sanitization in case the interface contains unexpected characters
     iface = config.sanitize_ifname(config.NETWORK_INTERFACE)
+    if not iface:
+        print("Interface invalida")
+        return
     logging.info("Monitorando interface %s...", iface)
     try:
         sniffer = AsyncSniffer(
@@ -66,6 +69,9 @@ def run():
         )
         sniffer.start()
         sniffer.join()
+    except ValueError as exc:
+        logging.error("Interface invalida: %s", exc)
+        print(f"Interface invalida: {exc}")
     except Exception as exc:
         logging.error("Falha ao iniciar sniffer: %s", exc)
         print(f"Erro ao iniciar captura: {exc}")


### PR DESCRIPTION
## Summary
- sanitize network interface names more thoroughly
- validate interface before starting scapy sniffer and show clearer errors

## Testing
- `python3 -m py_compile app/config.py app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_686884bc1284832a802aa15de6f0b48e