### PR TITLE
Improve interface validation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,15 +1,24 @@
 import os
+import re
 from dotenv import load_dotenv
 
 load_dotenv()
 
 
 def sanitize_ifname(iface: str) -> str:
-    """Return interface name without NUL bytes or surrounding whitespace."""
+    """Return a clean interface name without NUL bytes or stray characters."""
     if not isinstance(iface, str):
         iface = str(iface)
+
     # split at first NUL in case the string contains embedded characters
     iface = iface.split("\x00", 1)[0]
+
+    # remove newlines and control characters
+    iface = re.sub(r"[\r\n\t\f\v]", "", iface)
+
+    # keep only common iface characters (alnum, dash, underscore, colon, dot)
+    iface = re.sub(r"[^A-Za-z0-9_:\-\.]+", "", iface)
+
     return iface.strip()
 
 POSTGRES_USER = os.getenv('POSTGRES_USER')

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import logging
+import socket
 from scapy.all import AsyncSniffer
 from scapy.layers.inet import IP
 from . import config, db
@@ -59,6 +60,13 @@ def run():
     iface = config.sanitize_ifname(config.NETWORK_INTERFACE)
     if not iface:
         print("Interface invalida")
+        return
+
+    try:
+        socket.if_nametoindex(iface)
+    except OSError:
+        print(f"Interface invalida: {iface}")
+        logging.error("Interface invalida: %s", iface)
         return
     logging.info("Monitorando interface %s...", iface)
     try:


### PR DESCRIPTION
## Summary
- sanitize interface names more thoroughly
- validate network interface before starting sniffer

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686887a1eaa4832aa1da7886e0624b01