### PR TITLE
Fix interface sanitization

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -10,10 +10,13 @@ def sanitize_ifname(iface: str) -> str:
     if not isinstance(iface, str):
         iface = str(iface)
 
-    # split at first NUL in case the string contains embedded characters
-    iface = iface.split("\x00", 1)[0]
+    # remove everything after the first NUL byte if present
+    iface = iface.partition("\x00")[0]
 
-    # remove newlines and control characters
+    # remove any remaining NUL bytes just in case
+    iface = iface.replace("\x00", "")
+
+    # remove newlines and other common control characters
     iface = re.sub(r"[\r\n\t\f\v]", "", iface)
 
     # keep only common iface characters (alnum, dash, underscore, colon, dot)

--- a/app/main.py
+++ b/app/main.py
@@ -58,8 +58,9 @@ def run():
     db.init_db()
     # Defensive sanitization in case the interface contains unexpected characters
     iface = config.sanitize_ifname(config.NETWORK_INTERFACE)
-    if not iface:
+    if not iface or "\x00" in iface:
         print("Interface invalida")
+        logging.error("Interface continha caracteres invalidos")
         return
 
     try:
@@ -68,7 +69,7 @@ def run():
         print(f"Interface invalida: {iface}")
         logging.error("Interface invalida: %s", iface)
         return
-    logging.info("Monitorando interface %s...", iface)
+    logging.info("Monitorando interface %s...", repr(iface))
     try:
         sniffer = AsyncSniffer(
             iface=iface,


### PR DESCRIPTION
## Summary
- sanitize interface names more thoroughly
- validate interface string before sniffing
- log sanitized interface during startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688966e1d4832a82ea009cb64d8eef