### PR TITLE
Refactor security layer using HTTP proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,12 +12,13 @@ SEVERITY_MODEL=byviz/bylastic_classification_logs
 ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert
 NIDS_MODEL=Dumi2025/log-anomaly-detection-model-roberta
 
-# Interface to monitor
-NETWORK_INTERFACE=eth0
-
 # Device for model inference: "cpu" or "cuda"
 DEVICE=cpu
 # Port for the optional web panel
 WEB_PANEL_PORT=8080
-# Port for the Nginx Unit proxy
+# Port where the security proxy listens
 UNIT_PORT=8090
+# Port where the Nginx Unit container is exposed
+UNIT_BACKEND_PORT=18080
+# Backend URL for the Nginx Unit service
+BACKEND_URL=http://unit:8080

--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
 # Nginx Unit IA
 
-Este projeto cria uma camada de proteção inteligente para o proxy [Nginx Unit](https://unit.nginx.org/) utilizando modelos de linguagem do HuggingFace. Somente o Nginx Unit roda em container; os mecanismos de detecção, categorização e classificação devem ser executados fora do container.
+Este projeto cria uma camada de proteção inteligente para o proxy [Nginx Unit](https://unit.nginx.org/) utilizando modelos de linguagem do HuggingFace. Todo o tráfego que chega ao Nginx Unit passa antes por um proxy em Python que classifica as requisições e registra as detecções.
 
 ## Estrutura
-- `docker-compose.yml` define o serviço do proxy Nginx Unit e uma aplicação de teste "Hello World". A aplicação principal de detecção continua executando fora dos containers.
+- `docker-compose.yml` define o serviço do proxy Nginx Unit e uma aplicação de teste "Hello World". O proxy de segurança executa fora dos containers.
 - `Dockerfile` constroi a imagem para a aplicação, baixando os modelos necessários.
 - `app/` contém o código Python responsável pela detecção.
 - `schema.sql` contém a estrutura do banco de dados.
-- `.env.example` é um modelo de configuração (copie para `.env`). Inclui a variável `DEVICE` que define o dispositivo padrão (CPU ou GPU) e `UNIT_PORT` para alterar a porta do proxy Nginx Unit.
+- `.env.example` é um modelo de configuração (copie para `.env`). Inclui `UNIT_PORT` para a porta do proxy de segurança e `BACKEND_URL` apontando para o serviço Nginx Unit.
 - Caso o modelo de detecção de anomalias retorne rótulos genéricos (`LABEL_0`, `LABEL_1`), o código mapeia automaticamente esses valores para `normal` e `anomaly`.
 
 ## Uso rápido
 1. Copie `.env.example` para `.env` e ajuste as variáveis.
 2. Execute `docker-compose up -d` para subir o Nginx Unit e a aplicação de teste.
-3. Em seguida, rode `python -m app.menu` fora dos containers para iniciar a proteção
-   e o painel web. No menu é possível selecionar a interface de rede e o dispositivo
-   de inferência.
-   Ao escolher `5. Sair`, quaisquer serviços iniciados pelas opções anteriores são
-   finalizados automaticamente.
+3. Rode `python -m app.menu` para iniciar o proxy de segurança e, opcionalmente, o painel web.
+   O menu permite ativar ou desativar o proxy, iniciar o painel e escolher CPU ou GPU para inferência.
 
 A aplicação realiza análise semântica e detecção de anomalias nos logs. Caso variáveis de banco estejam configuradas, os resultados são armazenados no PostgreSQL informado.\
 Um painel web dinâmico (iniciado opcionalmente pelo menu) fica disponível em `http://localhost:8080/logs` para visualizar os logs registrados. O painel utiliza **Bootstrap** para uma interface mais limpa e permite alternar entre os modos claro e escuro.

--- a/app/config.py
+++ b/app/config.py
@@ -1,28 +1,7 @@
 import os
-import re
 from dotenv import load_dotenv
 
 load_dotenv()
-
-
-def sanitize_ifname(iface: str) -> str:
-    """Return a clean interface name without NUL bytes or stray characters."""
-    if not isinstance(iface, str):
-        iface = str(iface)
-
-    # remove everything after the first NUL byte if present
-    iface = iface.partition("\x00")[0]
-
-    # remove any remaining NUL bytes just in case
-    iface = iface.replace("\x00", "")
-
-    # remove newlines and other common control characters
-    iface = re.sub(r"[\r\n\t\f\v]", "", iface)
-
-    # keep only common iface characters (alnum, dash, underscore, colon, dot)
-    iface = re.sub(r"[^A-Za-z0-9_:\-\.]+", "", iface)
-
-    return iface.strip()
 
 POSTGRES_USER = os.getenv('POSTGRES_USER')
 POSTGRES_PASSWORD = os.getenv('POSTGRES_PASSWORD')
@@ -35,6 +14,7 @@ SEVERITY_MODEL = os.getenv('SEVERITY_MODEL')
 ANOMALY_MODEL = os.getenv('ANOMALY_MODEL')
 NIDS_MODEL = os.getenv('NIDS_MODEL')
 
-NETWORK_INTERFACE = sanitize_ifname(os.getenv('NETWORK_INTERFACE', 'eth0'))
 DEVICE = os.getenv('DEVICE', 'cpu')
 WEB_PANEL_PORT = int(os.getenv('WEB_PANEL_PORT', '8080'))
+UNIT_PORT = int(os.getenv('UNIT_PORT', '8090'))
+BACKEND_URL = os.getenv('BACKEND_URL', 'http://hello:8000')

--- a/app/menu.py
+++ b/app/menu.py
@@ -1,60 +1,55 @@
 import threading
 from werkzeug.serving import make_server
 import torch
-from scapy.all import get_if_list
-from . import config
-from . import main
-from . import wsgi
+from . import config, main, wsgi
 
-protection_thread = None
-web_server = None
-web_thread = None
+_proxy_thread = None
+_panel_server = None
+_panel_thread = None
 
 
-def start_protection():
-    global protection_thread
-    if protection_thread is None or not protection_thread.is_alive():
-        protection_thread = threading.Thread(target=main.run, daemon=True)
-        protection_thread.start()
-        print("Prote\u00e7\u00e3o ativada.")
+def start_proxy():
+    global _proxy_thread
+    if _proxy_thread is None or not _proxy_thread.is_alive():
+        _proxy_thread = threading.Thread(target=main.start, daemon=True)
+        _proxy_thread.start()
+        print("Proxy de seguran\u00e7a ativado.")
     else:
-        print("Prote\u00e7\u00e3o j\u00e1 em execu\u00e7\u00e3o.")
+        print("Proxy j\u00e1 em execu\u00e7\u00e3o.")
 
 
-def stop_protection():
-    global protection_thread
-    if protection_thread and protection_thread.is_alive():
+def stop_proxy():
+    global _proxy_thread
+    if _proxy_thread and _proxy_thread.is_alive():
         main.stop()
-        protection_thread.join()
-        protection_thread = None
-        print("Prote\u00e7\u00e3o desativada.")
+        _proxy_thread.join()
+        _proxy_thread = None
+        print("Proxy parado.")
     else:
-        print("Prote\u00e7\u00e3o n\u00e3o estava ativa.")
+        print("Proxy n\u00e3o estava ativo.")
 
 
 def start_panel():
-    """Start the web panel in a background thread."""
-    global web_server, web_thread
-    if web_server is None:
-        web_server = make_server("0.0.0.0", config.WEB_PANEL_PORT, wsgi.app)
-        web_thread = threading.Thread(target=web_server.serve_forever, daemon=True)
-        web_thread.start()
+    global _panel_server, _panel_thread
+    if _panel_server is None:
+        _panel_server = make_server("0.0.0.0", config.WEB_PANEL_PORT, wsgi.app)
+        _panel_thread = threading.Thread(target=_panel_server.serve_forever, daemon=True)
+        _panel_thread.start()
         print(f"Painel web em http://localhost:{config.WEB_PANEL_PORT}/logs")
     else:
         print("Painel web j\u00e1 em execu\u00e7\u00e3o.")
 
 
 def stop_panel():
-    """Stop the web panel if running."""
-    global web_server, web_thread
-    if web_server is not None:
-        web_server.shutdown()
-        web_thread.join()
-        web_server = None
-        web_thread = None
-        print("Painel web parado.")
+    global _panel_server, _panel_thread
+    if _panel_server is not None:
+        _panel_server.shutdown()
+        _panel_thread.join()
+        _panel_server = None
+        _panel_thread = None
+        print("Painel parado.")
     else:
-        print("Painel web n\u00e3o estava ativo.")
+        print("Painel n\u00e3o estava ativo.")
 
 
 def select_device():
@@ -64,71 +59,42 @@ def select_device():
     choice = input("Selecione: ")
     if choice == "1":
         device = "cpu"
-    elif choice == "2":
-        if torch.cuda.is_available():
-            device = "cuda"
-        else:
-            print("GPU n\u00e3o dispon\u00edvel, usando CPU")
-            device = "cpu"
+    elif choice == "2" and torch.cuda.is_available():
+        device = "cuda"
     else:
-        print("Escolha inv\u00e1lida.")
+        print("Escolha inv\u00e1lida ou GPU indispon\u00edvel.")
         return
-    if protection_thread and protection_thread.is_alive():
-        print("Pare a prote\u00e7\u00e3o antes de mudar o dispositivo.")
+    if _proxy_thread and _proxy_thread.is_alive():
+        print("Pare o proxy antes de mudar o dispositivo.")
         return
     config.DEVICE = device
     print(f"Dispositivo selecionado: {config.DEVICE}")
 
 
-def select_interface():
-    interfaces = [config.sanitize_ifname(iface) for iface in get_if_list()]
-    print("\nInterfaces dispon\u00edveis:")
-    for idx, iface in enumerate(interfaces, 1):
-        print(f"{idx}. {iface}")
-    choice = input("Selecione a interface: ")
-    try:
-        idx = int(choice) - 1
-        if idx < 0 or idx >= len(interfaces):
-            raise ValueError
-        if protection_thread and protection_thread.is_alive():
-            print("Pare a prote\u00e7\u00e3o antes de mudar a interface.")
-            return
-        selected = config.sanitize_ifname(interfaces[idx])
-        config.NETWORK_INTERFACE = selected
-        print(f"Interface selecionada: {config.NETWORK_INTERFACE}")
-    except ValueError:
-        print("Escolha inv\u00e1lida.")
-
-
 def menu():
     while True:
-        print(f"\nInterface atual: {config.NETWORK_INTERFACE}")
-        print(f"Dispositivo atual: {config.DEVICE}")
-        running = protection_thread is not None and protection_thread.is_alive()
-        panel = web_server is not None
-        print("1. " + ("Desativar" if running else "Ativar") + " prote\u00e7\u00e3o")
+        running = _proxy_thread is not None and _proxy_thread.is_alive()
+        panel = _panel_server is not None
+        print("\n1. " + ("Desativar" if running else "Ativar") + " proxy")
         print("2. " + ("Desativar" if panel else "Ativar") + " painel web")
-        print("3. Selecionar interface de rede")
-        print("4. Selecionar dispositivo (CPU/GPU)")
-        print("5. Sair")
+        print("3. Selecionar dispositivo (CPU/GPU)")
+        print("4. Sair")
         choice = input("Escolha: ")
         if choice == "1":
             if running:
-                stop_protection()
+                stop_proxy()
             else:
-                start_protection()
+                start_proxy()
         elif choice == "2":
             if panel:
                 stop_panel()
             else:
                 start_panel()
         elif choice == "3":
-            select_interface()
-        elif choice == "4":
             select_device()
-        elif choice == "5":
+        elif choice == "4":
             if running:
-                stop_protection()
+                stop_proxy()
             if panel:
                 stop_panel()
             break

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1,9 +1,48 @@
-from flask import Flask, render_template, jsonify
-from . import db, firewall
+from flask import Flask, render_template, jsonify, request, Response
+import requests
+from . import db, firewall, config
+from .detection import Detector
+
+BACKEND_URL = config.BACKEND_URL
+
+detector = Detector()
 
 app = Flask(__name__)
 
 db.init_db()
+
+
+@app.before_request
+def _analyze():
+    if request.path.startswith('/logs') or request.path.startswith('/blocked') or request.path.startswith('/api/'):
+        return
+    result = analyze_request()
+    if isinstance(result, dict) and result.get('blocked'):
+        return Response('Bloqueado', status=403)
+
+
+def analyze_request() -> dict:
+    """Analyze the current HTTP request using the ML models."""
+    payload = request.get_data(as_text=True) or ""
+    full_text = f"{request.method} {request.full_path}\n{payload}"
+    result = detector.analyze(full_text)
+    db.save_log(
+        'unit',
+        full_text,
+        result['severity'],
+        result['anomaly'],
+        result['nids'],
+    )
+    sev = str(result['severity']['label']).lower()
+    anom = str(result['anomaly']['label']).lower()
+    ip = request.remote_addr
+    if ip and (sev == 'high' or anom not in ('normal', 'none')):
+        if firewall.block_ip(ip):
+            reason = f"{result['anomaly']['label']} / {result['severity']['label']}"
+            db.save_blocked_ip(ip, reason)
+            return {'blocked': True}
+    return result
+
 
 @app.route('/')
 def index():
@@ -52,5 +91,29 @@ def api_blocked():
         for item in blocked
     ]
     return jsonify(serialized)
+
+
+def _forward(path: str):
+    url = f"{BACKEND_URL}/{path}" if path else BACKEND_URL
+    try:
+        resp = requests.request(
+            method=request.method,
+            url=url,
+            headers={k: v for k, v in request.headers if k.lower() != 'host'},
+            params=request.args,
+            data=request.get_data(),
+            allow_redirects=False,
+        )
+    except Exception as exc:
+        return Response(f"Erro ao encaminhar: {exc}", status=502)
+    excluded = {'content-encoding', 'content-length', 'transfer-encoding', 'connection'}
+    headers = [(k, v) for k, v in resp.headers.items() if k.lower() not in excluded]
+    return Response(resp.content, resp.status_code, headers)
+
+
+@app.route('/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'])
+@app.route('/', defaults={'path': ''}, methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'])
+def catch_all(path: str):
+    return _forward(path)
 
 application = app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - ./app:/www/app
       - ./unit-config.json:/docker-entrypoint.d/unit-config.json
     ports:
-      - "${UNIT_PORT:-8090}:8080"
+      - "${UNIT_BACKEND_PORT:-18080}:8080"
     depends_on:
       - hello
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 psycopg2-binary
 transformers
-scapy
 python-dotenv
 flask
 werkzeug

--- a/unit-config.json
+++ b/unit-config.json
@@ -12,12 +12,6 @@
         }
     },
     "routes": [
-        {
-            "match": { "uri": "/hello" },
-            "action": { "proxy": "http://hello:8000" }
-        },
-        {
-            "action": { "pass": "applications/dummy" }
-        }
+        { "action": { "pass": "applications/dummy" } }
     ]
 }


### PR DESCRIPTION
## Summary
- update README to explain new HTTP proxy approach
- rework configuration and add BACKEND_URL
- remove scapy-based sniffer and implement HTTP proxy in `wsgi.py`
- simplify menu to control proxy and panel
- clean requirements and docker-compose settings
- update env example and unit config

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68688c0f9370832a882756eb317581c0