### PR TITLE
Improve Portuguese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,59 @@
 # Nginx Unit IA
 
-Este projeto cria uma camada de proteção inteligente para o proxy [Nginx Unit](https://unit.nginx.org/) utilizando modelos de linguagem do HuggingFace. Todo o tráfego que chega ao Nginx Unit passa antes por um proxy em Python que classifica as requisições e registra as detecções.
+Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.nginx.org/) utilizando modelos de linguagem do HuggingFace. Todas as requisições passam por um proxy em Python que analisa e classifica o conteúdo antes de encaminhar ao Nginx Unit. Logs e IPs suspeitos podem ser armazenados em PostgreSQL e consultados por um painel web.
 
-## Estrutura
-- `docker-compose.yml` define o serviço do proxy Nginx Unit e uma aplicação de teste "Hello World". O proxy de segurança executa fora dos containers.
-- `Dockerfile` constroi a imagem para a aplicação, baixando os modelos necessários.
-- `app/` contém o código Python responsável pela detecção.
-- `schema.sql` contém a estrutura do banco de dados.
-- `.env.example` é um modelo de configuração (copie para `.env`). Inclui `UNIT_PORT` para a porta do proxy de segurança, `BACKEND_URL` apontando para o serviço Nginx Unit e `LOG_FILE` definindo onde salvar os registros.
-- Caso o modelo de detecção de anomalias retorne rótulos genéricos (`LABEL_0`, `LABEL_1`), o código mapeia automaticamente esses valores para `normal` e `anomaly`.
+## Funcionalidades
 
-## Uso rápido
-1. Copie `.env.example` para `.env` e ajuste as variáveis.
-2. Instale as dependências Python:
+- Classifica severidade, anomalias e categorias de rede (NIDS) de cada requisição.
+- Detecção semântica de comportamentos fora do padrão através de embeddings.
+- Bloqueio automático de IPs suspeitos com integração ao firewall **UFW**.
+- Painel web em Flask/Bootstrap com logs em tempo real e lista de IPs bloqueados.
+- Registro opcional em banco PostgreSQL com esquema definido em `schema.sql`.
+- Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
+
+## Instalação
+
+1. Copie `.env.example` para `.env` e ajuste as variáveis conforme o ambiente.
+2. Instale as dependências do Python:
    ```bash
    pip install -r requirements.txt
    ```
-3. Execute `docker-compose up -d` para subir o Nginx Unit e a aplicação de teste.
-4. Rode `python -m app.menu` para iniciar o proxy de segurança e, opcionalmente, o painel web.
-   O menu permite ativar ou desativar o proxy, iniciar o painel e escolher CPU ou GPU para inferência.
+3. (Opcional) Suba o contêiner do Nginx Unit e da aplicação de exemplo:
+   ```bash
+   docker-compose up -d
+   ```
 
-A aplicação realiza análise semântica e detecção de anomalias nos logs. Caso variáveis de banco estejam configuradas, os resultados são armazenados no PostgreSQL informado.\
-Um painel web dinâmico (iniciado opcionalmente pelo menu) fica disponível em `http://localhost:8080/logs` para visualizar os logs registrados. O painel utiliza **Bootstrap** para uma interface mais limpa e permite alternar entre os modos claro e escuro.
-Os registros de novos acessos são transmitidos em tempo real via Server-Sent Events, mantendo a página atualizada sem recarregamentos.
-Todos os eventos e erros também são gravados em arquivo definido pela variável `LOG_FILE`, facilitando a análise posterior.
+## Uso
 
-## Firewall e bloqueio de IPs
+Execute o menu interativo para controlar o proxy e o painel:
 
-A detecção de ameaças também integra-se ao firewall **UFW**. Sempre que um ataque ou invasão é identificado, o IP de origem é automaticamente bloqueado via UFW e registrado no banco de dados.
-O painel web possui a página `http://localhost:8080/blocked` que exibe todos os IPs bloqueados, seu status, motivo e data/hora do bloqueio.
-Sempre que essa página é acessada, a lista é sincronizada com as regras atuais do UFW, garantindo que o banco reflita o estado real do firewall.
-O proxy também monitora a quantidade de requisições de cada IP e bloqueia automaticamente padrões que indiquem ataques de negação de serviço.
+```bash
+python -m app.menu
+```
+
+O proxy escutará na porta configurada em `UNIT_PORT` e encaminhará as requisições para `BACKEND_URL`. O painel estará disponível em `http://localhost:8080` (ou porta definida em `WEB_PANEL_PORT`).
+
+### Painel
+
+- `/logs` &ndash; exibe os registros em tempo real usando Server-Sent Events.
+- `/blocked` &ndash; mostra os IPs bloqueados e sincroniza a lista com o UFW.
+
+### Firewall
+
+Quando uma requisição é classificada como perigosa ou excede o limiar de negação de serviço, o IP de origem é bloqueado no UFW e gravado no banco (se configurado). Os dados também ficam salvos em arquivo no caminho definido por `LOG_FILE`.
+
+## Banco de dados
+
+Defina `POSTGRES_HOST` e as demais variáveis de conexão para ativar o uso de PostgreSQL. Caso contrário, o proxy funciona sem dependência de banco, apenas registrando em arquivo.
+
+## Pentest e testes
+
+A pasta `pentest` inclui scripts de verificação:
+
+```bash
+python pentest/test_structure.py   # valida a estrutura do projeto
+python pentest/test_security.py    # envia uma requisição suspeita e consulta os logs
+```
+
+Execute o segundo teste com o proxy e o painel ativos.
+


### PR DESCRIPTION
## Summary
- rewrite Portuguese README with clearer setup and feature info

## Testing
- `python3 pentest/test_structure.py`
- `python3 pentest/test_security.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686932f1d274832a8487cad804a9a640