### PR TITLE
Fix web UI blocking by enabling threading

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ def start(port: int = None):
         return
     if port is None:
         port = config.UNIT_PORT
-    _server = make_server("0.0.0.0", port, wsgi.app)
+    _server = make_server("0.0.0.0", port, wsgi.app, threaded=True)
     _thread = threading.Thread(target=_server.serve_forever, daemon=True)
     _thread.start()
     logger.info("Proxy iniciado na porta %s", port)

--- a/app/menu.py
+++ b/app/menu.py
@@ -37,7 +37,9 @@ def stop_proxy():
 def start_panel():
     global _panel_server, _panel_thread
     if _panel_server is None:
-        _panel_server = make_server("0.0.0.0", config.WEB_PANEL_PORT, wsgi.app)
+        _panel_server = make_server(
+            "0.0.0.0", config.WEB_PANEL_PORT, wsgi.app, threaded=True
+        )
         _panel_thread = threading.Thread(target=_panel_server.serve_forever, daemon=True)
         _panel_thread.start()
         logger.info("Painel web iniciado na porta %s", config.WEB_PANEL_PORT)


### PR DESCRIPTION
## Summary
- start Flask servers in threaded mode

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6869364b0248832ab89a8a1e9d0cfd2f