### PR TITLE
Enable SSE updates for blocked IPs

### DIFF
--- a/app/events.py
+++ b/app/events.py
@@ -1,0 +1,46 @@
+import queue
+
+log_listeners = []
+blocked_listeners = []
+
+
+def register_log_listener():
+    q = queue.Queue()
+    log_listeners.append(q)
+    return q
+
+
+def unregister_log_listener(q):
+    try:
+        log_listeners.remove(q)
+    except ValueError:
+        pass
+
+
+def notify_log(entry):
+    for q in list(log_listeners):
+        try:
+            q.put_nowait(entry)
+        except Exception:
+            pass
+
+
+def register_blocked_listener():
+    q = queue.Queue()
+    blocked_listeners.append(q)
+    return q
+
+
+def unregister_blocked_listener(q):
+    try:
+        blocked_listeners.remove(q)
+    except ValueError:
+        pass
+
+
+def notify_blocked(entry):
+    for q in list(blocked_listeners):
+        try:
+            q.put_nowait(entry)
+        except Exception:
+            pass

--- a/app/templates/blocked.html
+++ b/app/templates/blocked.html
@@ -23,23 +23,32 @@
 
 {% block scripts %}
 <script>
+function addRow(item) {
+    const tbody = document.querySelector('#blocked-table tbody');
+    const tr = document.createElement('tr');
+    const statusClass = item.status === 'blocked' ? 'status-blocked' : 'status-unblocked';
+    tr.innerHTML = `
+        <td>${item.ip}</td>
+        <td class="${statusClass}">${item.status}</td>
+        <td>${item.reason || ''}</td>
+        <td>${item.blocked_at}</td>`;
+    tbody.prepend(tr);
+}
+
 async function fetchBlocked() {
     const res = await fetch('/api/blocked');
     const data = await res.json();
     const tbody = document.querySelector('#blocked-table tbody');
     tbody.innerHTML = '';
-    data.forEach(item => {
-        const tr = document.createElement('tr');
-        const statusClass = item.status === 'blocked' ? 'status-blocked' : 'status-unblocked';
-        tr.innerHTML = `
-            <td>${item.ip}</td>
-            <td class="${statusClass}">${item.status}</td>
-            <td>${item.reason || ''}</td>
-            <td>${item.blocked_at}</td>`;
-        tbody.appendChild(tr);
-    });
+    data.reverse().forEach(addRow);
 }
+
 fetchBlocked();
-setInterval(fetchBlocked, 5000);
+
+const evt = new EventSource('/stream/blocked');
+evt.onmessage = (e) => {
+    const item = JSON.parse(e.data);
+    addRow(item);
+};
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `events` module to handle log and blocked IP listeners
- emit SSE updates when IPs are blocked or unblocked
- expose `/stream/blocked` endpoint
- update blocked page to stream updates in real time

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686938a331f8832ab95fc254f1124091