### PR TITLE
Implement paginated logs and improved UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
 - Detecção semântica de comportamentos fora do padrão através de embeddings.
 - Bloqueio automático de IPs suspeitos com integração ao firewall **UFW**.
 - Painel web em Flask/Bootstrap com logs em tempo real e lista de IPs bloqueados.
+- Painel web em Flask/Bootstrap com paginação (100 itens por página), logs coloridos por categoria e exibição do modelo utilizado.
+- Barra superior exibe informações resumidas dos modelos carregados.
 - Registro opcional em banco PostgreSQL com esquema definido em `schema.sql`.
 - Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
 

--- a/app/db.py
+++ b/app/db.py
@@ -60,7 +60,7 @@ def save_blocked_ip(ip, reason, status="blocked"):
         )
 
 
-def get_logs(limit=100):
+def get_logs(limit=100, offset=0):
     if conn is None:
         return []
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
@@ -68,14 +68,14 @@ def get_logs(limit=100):
             """
             SELECT * FROM logs
             ORDER BY created_at DESC
-            LIMIT %s
+            LIMIT %s OFFSET %s
             """,
-            (limit,),
+            (limit, offset),
         )
         return cur.fetchall()
 
 
-def get_blocked_ips(limit=100):
+def get_blocked_ips(limit=100, offset=0):
     if conn is None:
         return []
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
@@ -83,9 +83,9 @@ def get_blocked_ips(limit=100):
             """
             SELECT * FROM blocked_ips
             ORDER BY blocked_at DESC
-            LIMIT %s
+            LIMIT %s OFFSET %s
             """,
-            (limit,),
+            (limit, offset),
         )
         return cur.fetchall()
 

--- a/app/detection.py
+++ b/app/detection.py
@@ -90,12 +90,25 @@ class Detector:
         nids_label = self.nids_model.config.id2label.get(nids_label_idx, str(nids_label_idx))
 
         return {
-            'anomaly': {'label': anomaly_label, 'score': anomaly_score},
-            'severity': {'label': severity_label, 'score': severity_score},
-            'nids': {'label': nids_label, 'score': nids_score},
+            'anomaly': {
+                'label': anomaly_label,
+                'score': anomaly_score,
+                'model': config.ANOMALY_MODEL,
+            },
+            'severity': {
+                'label': severity_label,
+                'score': severity_score,
+                'model': config.SEVERITY_MODEL,
+            },
+            'nids': {
+                'label': nids_label,
+                'score': nids_score,
+                'model': config.NIDS_MODEL,
+            },
             'semantic': {
                 'embedding': embedding.cpu().tolist(),
                 'similarity': similarity,
                 'outlier': outlier,
+                'model': config.SEMANTIC_MODEL,
             },
         }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,9 +15,18 @@
         .severity-low { color: #198754; font-weight: bold; }
         .status-blocked { color: #dc3545; font-weight: bold; }
         .status-unblocked { color: #198754; font-weight: bold; }
+        .category-label {
+            color: #000;
+            font-weight: bold;
+            padding: 2px 4px;
+            border-radius: 4px;
+        }
     </style>
 </head>
 <body>
+    <script>
+        window.MODEL_INFO = {{ models|tojson if models is defined else 'null' }};
+    </script>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top">
         <div class="container-fluid">
             <a class="navbar-brand" href="/logs">Nginx Unit IA</a>
@@ -29,6 +38,7 @@
                     <li class="nav-item"><a class="nav-link fw-bold text-white" style="font-size:1.1rem" href="/logs">Logs</a></li>
                     <li class="nav-item"><a class="nav-link fw-bold text-white" style="font-size:1.1rem" href="/blocked">IPs Bloqueados</a></li>
                 </ul>
+                <span id="model-info" class="navbar-text me-3 text-white small"></span>
                 <button id="toggle-btn" class="btn btn-outline-light">Alternar tema</button>
             </div>
         </div>
@@ -47,6 +57,9 @@ function toggleTheme(){
 }
 document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('toggle-btn').addEventListener('click', toggleTheme);
+    if (window.MODEL_INFO) {
+        document.getElementById('model-info').textContent = `S: ${MODEL_INFO.severity} | A: ${MODEL_INFO.anomaly} | N: ${MODEL_INFO.nids}`;
+    }
 });
 </script>
 {% block scripts %}{% endblock %}

--- a/app/templates/blocked.html
+++ b/app/templates/blocked.html
@@ -16,6 +16,11 @@
             </thead>
             <tbody></tbody>
         </table>
+        <div class="d-flex justify-content-between align-items-center p-2">
+            <button id="prev-page" class="btn btn-sm btn-secondary">Anterior</button>
+            <span id="page-info" class="fw-bold"></span>
+            <button id="next-page" class="btn btn-sm btn-secondary">Próxima</button>
+        </div>
     </div>
   </div>
 </div>
@@ -35,20 +40,34 @@ function addRow(item) {
     tbody.prepend(tr);
 }
 
-async function fetchBlocked() {
-    const res = await fetch('/api/blocked');
+let currentPage = {{ page }};
+let evt;
+
+async function fetchBlocked(page) {
+    const res = await fetch(`/api/blocked?page=${page}`);
     const data = await res.json();
     const tbody = document.querySelector('#blocked-table tbody');
     tbody.innerHTML = '';
-    data.reverse().forEach(addRow);
+    data.forEach(addRow);
+    document.getElementById('page-info').textContent = `Página ${page}`;
+    currentPage = page;
+    if (evt) evt.close();
+    if (page === 1) {
+        evt = new EventSource('/stream/blocked');
+        evt.onmessage = (e) => {
+            const item = JSON.parse(e.data);
+            addRow(item);
+        };
+    }
 }
 
-fetchBlocked();
+document.getElementById('prev-page').addEventListener('click', () => {
+    if (currentPage > 1) fetchBlocked(currentPage - 1);
+});
+document.getElementById('next-page').addEventListener('click', () => {
+    fetchBlocked(currentPage + 1);
+});
 
-const evt = new EventSource('/stream/blocked');
-evt.onmessage = (e) => {
-    const item = JSON.parse(e.data);
-    addRow(item);
-};
+fetchBlocked(currentPage);
 </script>
 {% endblock %}

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -13,12 +13,18 @@
                     <th>Log</th>
                     <th>Severity</th>
                     <th>Anomaly</th>
-                    <th>Category</th>
-                    <th>Outlier</th>
+                    <th>Ação</th>
+                    <th>Inesperado</th>
+                    <th>Modelos</th>
                 </tr>
             </thead>
             <tbody></tbody>
-</table>
+        </table>
+        <div class="d-flex justify-content-between align-items-center p-2">
+            <button id="prev-page" class="btn btn-sm btn-secondary">Anterior</button>
+            <span id="page-info" class="fw-bold"></span>
+            <button id="next-page" class="btn btn-sm btn-secondary">Próxima</button>
+        </div>
     </div>
   </div>
 </div>
@@ -26,33 +32,61 @@
 
 {% block scripts %}
 <script>
+function categoryColor(cat) {
+    let hash = 0;
+    for (let i = 0; i < cat.length; i++) {
+        hash = cat.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    const hue = Math.abs(hash) % 360;
+    return `hsl(${hue},70%,80%)`;
+}
+
 function addLogRow(log) {
     const tbody = document.querySelector('#logs-table tbody');
     const tr = document.createElement('tr');
     const sevClass = log.severity.label ? 'severity-' + log.severity.label.toLowerCase() : '';
+    const catStyle = `background-color:${categoryColor(log.nids.label)}`;
+    const models = `S:${log.severity.model} A:${log.anomaly.model} N:${log.nids.model}`;
     tr.innerHTML = `
         <td>${log.created_at}</td>
         <td>${log.iface}</td>
         <td>${log.log}</td>
-        <td class="${sevClass}">${log.severity.label}</td>
-        <td>${log.anomaly.label}</td>
-        <td>${log.nids.label}</td>
-        <td>${log.semantic.outlier ? 'yes' : 'no'}</td>`;
+        <td class="${sevClass}" title="${log.severity.model}">${log.severity.label}</td>
+        <td title="${log.anomaly.model}">${log.anomaly.label}</td>
+        <td><span class="category-label" style="${catStyle}" title="${log.nids.model}">${log.nids.label}</span></td>
+        <td>${log.semantic.outlier ? 'sim' : 'não'}</td>
+        <td>${models}</td>`;
     tbody.prepend(tr);
 }
 
-async function initLogs() {
-    const res = await fetch('/api/logs');
-    const data = await res.json();
-    data.reverse().forEach(addLogRow);
+let currentPage = {{ page }};
+let evt;
 
-    const evt = new EventSource('/stream/logs');
-    evt.onmessage = (e) => {
-        const log = JSON.parse(e.data);
-        addLogRow(log);
-    };
+async function fetchLogs(page) {
+    const res = await fetch(`/api/logs?page=${page}`);
+    const data = await res.json();
+    const tbody = document.querySelector('#logs-table tbody');
+    tbody.innerHTML = '';
+    data.forEach(addLogRow);
+    document.getElementById('page-info').textContent = `Página ${page}`;
+    currentPage = page;
+    if (evt) evt.close();
+    if (page === 1) {
+        evt = new EventSource('/stream/logs');
+        evt.onmessage = (e) => {
+            const log = JSON.parse(e.data);
+            addLogRow(log);
+        };
+    }
 }
 
-initLogs();
+document.getElementById('prev-page').addEventListener('click', () => {
+    if (currentPage > 1) fetchLogs(currentPage - 1);
+});
+document.getElementById('next-page').addEventListener('click', () => {
+    fetchLogs(currentPage + 1);
+});
+
+fetchLogs(currentPage);
 </script>
 {% endblock %}

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -108,19 +108,28 @@ def index():
 
 @app.route('/logs')
 def logs():
-    logs = db.get_logs(limit=200)
-    return render_template('logs.html', title='Logs', logs=logs)
+    page = int(request.args.get('page', '1'))
+    logs = db.get_logs(limit=100, offset=(page - 1) * 100)
+    models = {
+        'severity': config.SEVERITY_MODEL,
+        'anomaly': config.ANOMALY_MODEL,
+        'nids': config.NIDS_MODEL,
+        'semantic': config.SEMANTIC_MODEL,
+    }
+    return render_template('logs.html', title='Logs', logs=logs, page=page, models=models)
 
 
 @app.route('/blocked')
 def blocked():
+    page = int(request.args.get('page', '1'))
     firewall.sync_blocked_ips_with_ufw()
-    blocked = db.get_blocked_ips(limit=200)
-    return render_template('blocked.html', title='IPs Bloqueados', blocked=blocked)
+    blocked = db.get_blocked_ips(limit=100, offset=(page - 1) * 100)
+    return render_template('blocked.html', title='IPs Bloqueados', blocked=blocked, page=page)
 
 @app.route('/api/logs')
 def api_logs():
-    logs = db.get_logs(limit=200)
+    page = int(request.args.get('page', '1'))
+    logs = db.get_logs(limit=100, offset=(page - 1) * 100)
     serialized = [
         {
             'created_at': str(log['created_at']),
@@ -166,8 +175,9 @@ def stream_blocked():
 
 @app.route('/api/blocked')
 def api_blocked():
+    page = int(request.args.get('page', '1'))
     firewall.sync_blocked_ips_with_ufw()
-    blocked = db.get_blocked_ips(limit=200)
+    blocked = db.get_blocked_ips(limit=100, offset=(page - 1) * 100)
     serialized = [
         {
             'ip': item['ip'],


### PR DESCRIPTION
## Summary
- add model name metadata to detection output
- support pagination in DB queries
- expose pagination on /logs and /blocked routes and APIs
- display loaded model info in navbar
- show model names in log table and colorize categories
- add pagination controls to logs and blocked pages
- update README with new features

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68693cf1de78832ab20510c79704ac1e