### PR TITLE
Store IP metadata with logs

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -27,18 +27,20 @@ def init_db():
             cur.execute(f.read())
 
 
-def save_log(interface, data, severity, anomaly, nids, semantic=None):
+def save_log(interface, data, severity, anomaly, nids, semantic=None, ip=None, ip_info=None):
     if conn is None:
         return
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute(
             """
-            INSERT INTO logs (iface, log, severity, anomaly, nids, semantic)
-            VALUES (%s, %s, %s, %s, %s, %s)
+            INSERT INTO logs (iface, log, ip, ip_info, severity, anomaly, nids, semantic)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 interface,
                 data,
+                ip,
+                Json(ip_info) if ip_info is not None else None,
                 Json(severity),
                 Json(anomaly),
                 Json(nids),

--- a/app/ipinfo.py
+++ b/app/ipinfo.py
@@ -1,0 +1,15 @@
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_ip_info(ip: str):
+    """Return IP information from ipinfo.io or None on failure."""
+    try:
+        resp = requests.get(f"https://ipinfo.io/{ip}/json", timeout=5)
+        if resp.ok:
+            return resp.json()
+    except Exception as exc:
+        logger.error("Failed to fetch IP info for %s: %s", ip, exc)
+    return None

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -10,6 +10,7 @@
                 <tr>
                     <th>Timestamp</th>
                     <th>Interface</th>
+                    <th>IP</th>
                     <th>Log</th>
                     <th>Severity</th>
                     <th>Anomaly</th>
@@ -47,9 +48,11 @@ function addLogRow(log) {
     const sevClass = log.severity.label ? 'severity-' + log.severity.label.toLowerCase() : '';
     const catStyle = `background-color:${categoryColor(log.nids.label)}`;
     const models = `S:${log.severity.model} A:${log.anomaly.model} N:${log.nids.model}`;
+    const ipInfo = log.ip_info ? `${log.ip_info.city || ''}, ${log.ip_info.country || ''}` : '';
     tr.innerHTML = `
         <td>${log.created_at}</td>
         <td>${log.iface}</td>
+        <td title="${ipInfo}">${log.ip || ''}</td>
         <td>${log.log}</td>
         <td class="${sevClass}" title="${log.severity.model}">${log.severity.label}</td>
         <td title="${log.anomaly.model}">${log.anomaly.label}</td>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv
 flask
 werkzeug
 torch
+requests

--- a/schema.sql
+++ b/schema.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS logs (
     created_at TIMESTAMPTZ DEFAULT NOW(),
     iface TEXT NOT NULL,
     log TEXT NOT NULL,
+    ip TEXT,
+    ip_info JSONB,
     severity JSONB,
     anomaly JSONB,
     nids JSONB,


### PR DESCRIPTION
## Summary
- track request IP details in the database
- expose IP and extra info through `/api/logs` and SSE
- show IP data on the Logs page
- include `requests` library for IP lookups

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68693f1eaaac832a985954119cc96b2e