### PR TITLE
Sync blocked list with UFW

### DIFF
--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -21,6 +21,12 @@ app = Flask(__name__)
 
 db.init_db()
 
+
+@app.before_first_request
+def _sync_initial_blocked():
+    """Ensure database reflects current UFW state on startup."""
+    firewall.sync_blocked_ips_with_ufw()
+
 # Streaming listeners and DoS tracking
 REQUEST_COUNTS = defaultdict(deque)
 REQUEST_WINDOW = 10  # seconds


### PR DESCRIPTION
## Summary
- synchronize blocked IP records with actual UFW rules
- ensure DB/UFW sync happens on first request

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68694bbe493c832abc9f34b144c0be1f