### PR TITLE
Fix startup sync for Flask 3

### DIFF
--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -22,10 +22,13 @@ app = Flask(__name__)
 db.init_db()
 
 
-@app.before_first_request
-def _sync_initial_blocked():
+def _sync_initial_blocked() -> None:
     """Ensure database reflects current UFW state on startup."""
     firewall.sync_blocked_ips_with_ufw()
+
+# ``before_first_request`` was removed in Flask 3.x. Call the function once
+# during startup instead of registering it as a hook.
+_sync_initial_blocked()
 
 # Streaming listeners and DoS tracking
 REQUEST_COUNTS = defaultdict(deque)


### PR DESCRIPTION
## Summary
- initialize firewall sync on startup instead of relying on deprecated `before_first_request`
- ran structure and security test scripts

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68694d221ef0832a83c6309911e6f4cc