### PR TITLE
Add attack test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,15 @@ Defina `POSTGRES_HOST` e as demais variáveis de conexão para ativar o uso de P
 
 ## Pentest e testes
 
-A pasta `pentest` inclui scripts de verificação:
+A pasta `pentest` inclui scripts de verificação e testes de ataque:
 
 ```bash
 python pentest/test_structure.py   # valida a estrutura do projeto
 python pentest/test_security.py    # envia uma requisição suspeita e consulta os logs
+python pentest/test_attacks.py     # executa vários vetores de ataque contra o proxy
 ```
 
-Execute o segundo teste com o proxy e o painel ativos.
+Execute os testes de segurança com o proxy e o painel ativos.
 
 A detecção de ameaças também integra-se ao firewall **UFW**. Sempre que um ataque ou invasão é identificado, o IP de origem é automaticamente bloqueado via UFW e registrado no banco de dados.
 O painel web possui a página `http://localhost:8080/blocked` que exibe todos os IPs bloqueados, seu status, motivo e data/hora do bloqueio.

--- a/pentest/README.md
+++ b/pentest/README.md
@@ -19,3 +19,13 @@ O script `test_security.py` envia uma requisição contendo um payload suspeito 
 ```bash
 python pentest/test_security.py
 ```
+
+## Teste de múltiplos ataques
+
+O script `test_attacks.py` dispara diversas requisições com diferentes vetores
+de ataque (XSS, SQL injection, path traversal, etc.) e mostra o total de logs e
+de IPs bloqueados ao final.
+
+```bash
+python pentest/test_attacks.py
+```

--- a/pentest/test_attacks.py
+++ b/pentest/test_attacks.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Executa múltiplos testes simulando diferentes vetores de ataque."""
+import os
+import time
+import json
+import urllib.request
+import urllib.parse
+
+UNIT_PORT = int(os.getenv("UNIT_PORT", "8090"))
+WEB_PANEL_PORT = int(os.getenv("WEB_PANEL_PORT", "8080"))
+
+ATTACKS = {
+    "xss": "<script>alert('XSS')</script>",
+    "sqli": "' OR '1'='1' --",
+    "path_traversal": "../../../../etc/passwd",
+    "cmd_injection": "; cat /etc/passwd",
+    "dos": "A" * 5000,
+}
+
+
+def send_request(payload: str) -> None:
+    url = f"http://localhost:{UNIT_PORT}/?data={urllib.parse.quote(payload)}"
+    try:
+        with urllib.request.urlopen(url) as resp:
+            resp.read()
+        print(f"Requisição enviada para {url}")
+    except Exception as exc:
+        print(f"Falha ao enviar requisição: {exc}")
+
+
+def fetch_json(path: str):
+    url = f"http://localhost:{WEB_PANEL_PORT}{path}"
+    with urllib.request.urlopen(url) as resp:
+        return json.loads(resp.read().decode())
+
+
+def main() -> None:
+    for name, payload in ATTACKS.items():
+        print(f"Testando ataque: {name}")
+        send_request(payload)
+        time.sleep(1)
+
+    logs = fetch_json("/api/logs")
+    blocked = fetch_json("/api/blocked")
+    print(f"Total de logs: {len(logs)}")
+    print(f"IPs bloqueados: {len(blocked)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `test_attacks.py` to pentest utilities to simulate many attack vectors
- document pentest folder and new script in the main README
- describe the new test in `pentest/README.md`

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_attacks.py` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_68694f4233a8832a826714286f820cb9