### PR TITLE
Add automatic model download before menu

### DIFF
--- a/app/menu.py
+++ b/app/menu.py
@@ -3,6 +3,7 @@ from werkzeug.serving import make_server
 import torch
 import logging
 from . import config, main, wsgi
+from .preload import download_models
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +115,9 @@ def whitelist_menu():
 
 
 def menu():
+    print("Verificando modelos, aguarde...")
+    download_models()
+    print("Modelos prontos.")
     while True:
         running = _proxy_thread is not None and _proxy_thread.is_alive()
         panel = _panel_server is not None

--- a/app/preload.py
+++ b/app/preload.py
@@ -1,0 +1,29 @@
+import logging
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+from sentence_transformers import SentenceTransformer
+
+from . import config
+
+logger = logging.getLogger(__name__)
+
+
+def download_models() -> None:
+    """Download all HuggingFace models used by the application."""
+    logger.info("Baixando modelos para o cache se necessario")
+    models = [
+        (config.SEVERITY_MODEL, True),
+        (config.ANOMALY_MODEL, True),
+        (config.NIDS_MODEL, True),
+    ]
+    for model_name, is_classifier in models:
+        try:
+            AutoTokenizer.from_pretrained(model_name)
+            if is_classifier:
+                AutoModelForSequenceClassification.from_pretrained(model_name)
+        except Exception as exc:
+            logger.error("Erro ao baixar %s: %s", model_name, exc)
+    try:
+        SentenceTransformer(config.SEMANTIC_MODEL)
+    except Exception as exc:
+        logger.error("Erro ao baixar modelo semantico %s: %s", config.SEMANTIC_MODEL, exc)
+    logger.info("Modelos verificados")


### PR DESCRIPTION
## Summary
- add `preload` module to fetch HuggingFace models in advance
- call the download step when starting the interactive menu

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686951ef7a64832aa3a76e83193aa09a