### PR TITLE
Improve request handling and tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,5 @@
 import threading
 from werkzeug.serving import make_server
-import threading
 import logging
 from . import config, wsgi
 

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -38,7 +38,12 @@ DOS_THRESHOLD = 20
 
 @app.before_request
 def _analyze():
-    if request.path.startswith('/logs') or request.path.startswith('/blocked') or request.path.startswith('/api/'):
+    if (
+        request.path.startswith('/logs')
+        or request.path.startswith('/blocked')
+        or request.path.startswith('/api/')
+        or request.path.startswith('/stream/')
+    ):
         return
     result = analyze_request()
     if isinstance(result, dict) and result.get('blocked'):
@@ -225,6 +230,7 @@ def _forward(path: str):
             params=request.args,
             data=request.get_data(),
             allow_redirects=False,
+            timeout=5,
         )
     except Exception as exc:
         return Response(f"Erro ao encaminhar: {exc}", status=502)

--- a/pentest/test_attacks.py
+++ b/pentest/test_attacks.py
@@ -21,7 +21,7 @@ ATTACKS = {
 def send_request(payload: str) -> None:
     url = f"http://localhost:{UNIT_PORT}/?data={urllib.parse.quote(payload)}"
     try:
-        with urllib.request.urlopen(url) as resp:
+        with urllib.request.urlopen(url, timeout=5) as resp:
             resp.read()
         print(f"Requisição enviada para {url}")
     except Exception as exc:
@@ -30,8 +30,12 @@ def send_request(payload: str) -> None:
 
 def fetch_json(path: str):
     url = f"http://localhost:{WEB_PANEL_PORT}{path}"
-    with urllib.request.urlopen(url) as resp:
-        return json.loads(resp.read().decode())
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as exc:
+        print(f"Falha ao acessar {url}: {exc}")
+        return None
 
 
 def main() -> None:
@@ -42,6 +46,9 @@ def main() -> None:
 
     logs = fetch_json("/api/logs")
     blocked = fetch_json("/api/blocked")
+    if logs is None or blocked is None:
+        print("Proxy ou painel web parece inativo.")
+        return
     print(f"Total de logs: {len(logs)}")
     print(f"IPs bloqueados: {len(blocked)}")
 

--- a/pentest/test_security.py
+++ b/pentest/test_security.py
@@ -12,7 +12,7 @@ WEB_PANEL_PORT = int(os.getenv("WEB_PANEL_PORT", "8080"))
 def send_request(payload: str) -> None:
     url = f"http://localhost:{UNIT_PORT}/?data={payload}"
     try:
-        with urllib.request.urlopen(url) as resp:
+        with urllib.request.urlopen(url, timeout=5) as resp:
             resp.read()
         print(f"Requisição enviada para {url}")
     except Exception as exc:
@@ -21,8 +21,12 @@ def send_request(payload: str) -> None:
 
 def fetch_json(path: str):
     url = f"http://localhost:{WEB_PANEL_PORT}{path}"
-    with urllib.request.urlopen(url) as resp:
-        return json.loads(resp.read().decode())
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as exc:
+        print(f"Falha ao acessar {url}: {exc}")
+        return None
 
 
 def main() -> None:
@@ -30,12 +34,18 @@ def main() -> None:
     send_request(payload)
     time.sleep(2)  # aguarda processamento do log
     logs = fetch_json("/api/logs")
+    if logs is None:
+        print("Proxy ou painel web parece inativo.")
+        return
     if any(payload in entry.get('log', '') for entry in logs):
         print("Payload encontrado nos logs.")
     else:
         print("Payload NÃO encontrado nos logs.")
 
     blocked = fetch_json("/api/blocked")
+    if blocked is None:
+        print("Não foi possível obter a lista de IPs bloqueados.")
+        return
     if blocked:
         print("IPs bloqueados:")
         for item in blocked:


### PR DESCRIPTION
## Summary
- skip analysis for `/stream/` endpoints
- set timeout when forwarding requests
- remove duplicate import in `app.main`
- make pentest scripts resilient to server downtime and add request timeouts

## Testing
- `python3 -m pentest.test_structure`
- `python3 -m pentest.test_security`
- `python3 -m pentest.test_attacks`
- `python3 -m py_compile app/*.py pentest/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68695640fc98832ab3f8b62c48772865