### PR TITLE
Improve proxy menu and dashboard

### DIFF
--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -5,11 +5,13 @@ from . import config
 
 
 def configure_logging():
-    handlers = [logging.StreamHandler()]
+    handlers = []
     if config.LOG_FILE:
         log_path = Path(config.LOG_FILE)
         log_path.parent.mkdir(parents=True, exist_ok=True)
-        handlers.append(RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3))
+        handlers.append(
+            RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3)
+        )
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,6 +21,11 @@
             padding: 2px 4px;
             border-radius: 4px;
         }
+        .log-cell {
+            max-width: 400px;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
     </style>
 </head>
 <body>

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -11,6 +11,8 @@
                     <th>Timestamp</th>
                     <th>Interface</th>
                     <th>IP</th>
+                    <th>Tipo Ataque</th>
+                    <th>Intensidade</th>
                     <th>Log</th>
                     <th>Severity</th>
                     <th>Anomaly</th>
@@ -53,7 +55,9 @@ function addLogRow(log) {
         <td>${log.created_at}</td>
         <td>${log.iface}</td>
         <td title="${ipInfo}">${log.ip || ''}</td>
-        <td>${log.log}</td>
+        <td>${log.nids.label}</td>
+        <td>${log.severity.label}</td>
+        <td class="log-cell">${log.log}</td>
         <td class="${sevClass}" title="${log.severity.model}">${log.severity.label}</td>
         <td title="${log.anomaly.model}">${log.anomaly.label}</td>
         <td><span class="category-label" style="${catStyle}" title="${log.nids.model}">${log.nids.label}</span></td>


### PR DESCRIPTION
## Summary
- disable console logging so menu isn't flooded
- show attack type and intensity columns on Logs page
- constrain log column width for better layout

## Testing
- `pytest -q`
- `python -m py_compile app/logging_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_686958b4658c832a97444c33991fd29c