### PR TITLE
Add attack type classification

### DIFF
--- a/app/attack_classifier.py
+++ b/app/attack_classifier.py
@@ -1,0 +1,18 @@
+import re
+
+PATTERNS = [
+    (re.compile(r"<script", re.I), "xss"),
+    (re.compile(r"(\bselect\b|\binsert\b|\bunion\b|\bdrop\b|\bor\s+1=1)", re.I), "sql_injection"),
+    (re.compile(r"\.\./|\.\.\\"), "path_traversal"),
+    (re.compile(r"[;&|`]|\b(cat|bash|sh)\b", re.I), "command_injection"),
+]
+
+
+def classify(text: str) -> str:
+    """Return a simple attack type label based on regex patterns."""
+    for pattern, label in PATTERNS:
+        if pattern.search(text):
+            return label
+    if len(text) > 1000:
+        return "dos"
+    return "normal"

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -55,7 +55,7 @@ function addLogRow(log) {
         <td>${log.created_at}</td>
         <td>${log.iface}</td>
         <td title="${ipInfo}">${log.ip || ''}</td>
-        <td>${log.nids.label}</td>
+        <td>${log.attack_type || log.nids.label}</td>
         <td>${log.severity.label}</td>
         <td class="log-cell">${log.log}</td>
         <td class="${sevClass}" title="${log.severity.model}">${log.severity.label}</td>


### PR DESCRIPTION
## Summary
- add new attack classification module using regex heuristics
- compute and display attack type in logs via Flask API and SSE events

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6869632118bc832a973acadd61b77251