### PR TITLE
Improve attack classifier patterns

### DIFF
--- a/app/attack_classifier.py
+++ b/app/attack_classifier.py
@@ -1,18 +1,57 @@
+import os
 import re
 
-PATTERNS = [
-    (re.compile(r"<script", re.I), "xss"),
-    (re.compile(r"(\bselect\b|\binsert\b|\bunion\b|\bdrop\b|\bor\s+1=1)", re.I), "sql_injection"),
-    (re.compile(r"\.\./|\.\.\\"), "path_traversal"),
-    (re.compile(r"[;&|`]|\b(cat|bash|sh)\b", re.I), "command_injection"),
-]
+
+THRESHOLD = int(os.getenv("ATTACK_SIZE_THRESHOLD", "1000"))
+
+
+def ml_multiclass_predict(text: str) -> str:
+    """Placeholder ML classification returning ``normal`` by default."""
+    return "normal"
+
+
+def _load_patterns():
+    return [
+        # XSS attempts including tag variations
+        (
+            re.compile(r"<\s*(script|img|iframe)[^>]*>.*?<\s*/\s*\1\s*>", re.I | re.S),
+            "xss",
+        ),
+        # Common SQL injection keywords
+        (
+            re.compile(
+                r"(?i)(?:union\s+select|select\s+.+\s+from|insert\s+into|drop\s+table|or\s+1=1)"
+            ),
+            "sql_injection",
+        ),
+        # Directory traversal including encoded variants
+        (re.compile(r"(?:\.\.\/|\.\.\\|%2e%2e\/|%2e%2e\\)", re.I), "path_traversal"),
+        # Command injection characters
+        (re.compile(r"[;&|`]|\b(cat|bash|sh)\b", re.I), "command_injection"),
+        # URLs inside parameters that may indicate open redirect
+        (re.compile(r"(?:https?|ftp)://[^\s\"']+", re.I), "open_redirect"),
+        # File inclusion patterns
+        (
+            re.compile(r"(?:\binclude\b|\brequire\b)[^\n]+\.(?:php|cfg|txt)", re.I),
+            "file_inclusion",
+        ),
+        # XML External Entity
+        (re.compile(r"<!DOCTYPE\s+[^>]*\[\s*<!ENTITY\s+[^>]*>", re.I), "xxe"),
+        # HTTP header injection
+        (re.compile(r"\r?\n\s*[A-Za-z-]+:", re.I), "header_injection"),
+        # Hidden field tampering
+        (re.compile(r"hidden\s*=\s*['\"]?\w+['\"]?", re.I), "form_tampering"),
+    ]
+
+
+PATTERNS = _load_patterns()
 
 
 def classify(text: str) -> str:
-    """Return a simple attack type label based on regex patterns."""
+    """Classify the text into an attack category."""
     for pattern, label in PATTERNS:
         if pattern.search(text):
             return label
-    if len(text) > 1000:
+    if len(text) > THRESHOLD:
         return "dos"
-    return "normal"
+    return ml_multiclass_predict(text)


### PR DESCRIPTION
## Summary
- expand regex patterns for detecting XSS, SQLi, path traversal, command injection and more
- add placeholder machine learning fallback classifier
- make DoS threshold configurable via `ATTACK_SIZE_THRESHOLD`

## Testing
- `python pentest/test_structure.py`
- `python -m py_compile $(git ls-files '*.py')`
- `python pentest/test_attacks.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686965fe756c832aa98f491c219e8cc5