### PR TITLE
Add log detail view with intensity metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
 - Bloqueio automático de IPs suspeitos com integração ao firewall **UFW**.
 - Painel web em Flask/Bootstrap com logs em tempo real e lista de IPs bloqueados.
 - Painel web em Flask/Bootstrap com paginação (100 itens por página), logs coloridos por categoria e exibição do modelo utilizado.
+- Cálculo de intensidade de ataque combinando resultados dos modelos.
+- Visualização detalhada de cada log com todas as informações classificadas.
 - Barra superior exibe informações resumidas dos modelos carregados.
 - Registro opcional em banco PostgreSQL com esquema definido em `schema.sql`.
 - Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
@@ -39,6 +41,7 @@ O proxy escutará na porta configurada em `UNIT_PORT` e encaminhará as requisi�
 
 - `/logs` &ndash; exibe os registros em tempo real usando Server-Sent Events.
 - `/blocked` &ndash; mostra os IPs bloqueados e sincroniza a lista com o UFW.
+- `/log/<id>` &ndash; página individual com detalhes completos do log.
 
 ### Firewall
 

--- a/app/templates/log_detail.html
+++ b/app/templates/log_detail.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h1 class="display-5 mb-4 text-center">Detalhes do Log</h1>
+<div class="card">
+  <div class="card-body">
+    <p><strong>ID:</strong> {{ log.id }}</p>
+    <p><strong>Timestamp:</strong> {{ log.created_at }}</p>
+    <p><strong>Interface:</strong> {{ log.iface }}</p>
+    <p><strong>IP:</strong> {{ log.ip }}</p>
+    <p><strong>Tipo Ataque:</strong> {{ log.attack_type }}</p>
+    <p><strong>Intensidade:</strong> {{ intensity }}</p>
+    <pre class="mt-3">{{ log.log }}</pre>
+    <p><strong>Severity:</strong> {{ log.severity.label }}</p>
+    <p><strong>Anomaly:</strong> {{ log.anomaly.label }}</p>
+    <p><strong>Categoria:</strong> {{ log.nids.label }}</p>
+    <p><strong>Similaridade:</strong> {{ log.semantic.similarity }}</p>
+    <p><strong>Modelos:</strong> S: {{ log.severity.model }} | A: {{ log.anomaly.model }} | N: {{ log.nids.model }}</p>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -44,6 +44,10 @@ function categoryColor(cat) {
     return `hsl(${hue},70%,80%)`;
 }
 
+function abbreviate(text, len = 60) {
+    return text.length > len ? text.slice(0, len) + '...' : text;
+}
+
 function addLogRow(log) {
     const tbody = document.querySelector('#logs-table tbody');
     const tr = document.createElement('tr');
@@ -51,13 +55,14 @@ function addLogRow(log) {
     const catStyle = `background-color:${categoryColor(log.nids.label)}`;
     const models = `S:${log.severity.model} A:${log.anomaly.model} N:${log.nids.model}`;
     const ipInfo = log.ip_info ? `${log.ip_info.city || ''}, ${log.ip_info.country || ''}` : '';
+    const logLink = `<a href="/log/${log.id}" class="text-decoration-none">${abbreviate(log.log)}</a>`;
     tr.innerHTML = `
         <td>${log.created_at}</td>
         <td>${log.iface}</td>
         <td title="${ipInfo}">${log.ip || ''}</td>
         <td>${log.attack_type || log.nids.label}</td>
-        <td>${log.severity.label}</td>
-        <td class="log-cell">${log.log}</td>
+        <td>${log.intensity}</td>
+        <td class="log-cell">${logLink}</td>
         <td class="${sevClass}" title="${log.severity.model}">${log.severity.label}</td>
         <td title="${log.anomaly.model}">${log.anomaly.label}</td>
         <td><span class="category-label" style="${catStyle}" title="${log.nids.model}">${log.nids.label}</span></td>


### PR DESCRIPTION
## Summary
- compute attack intensity from LLM results
- include intensity in API and SSE logs
- return inserted log ID when saving
- provide `/log/<id>` route and template for detailed log view
- show abbreviated log links in logs table
- document new features

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: connection refused)*
- `python pentest/test_attacks.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68696844de88832a83f34b7982427e69