### PR TITLE
Improve attack detection regex patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
 - Barra superior exibe informações resumidas dos modelos carregados.
 - Registro opcional em banco PostgreSQL com esquema definido em `schema.sql`.
 - Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
-- Conjunto de regex robustos para detectar XSS, SQLi, path traversal e outros ataques, com fallback para modelo de linguagem e cuidado contra ReDoS.
+- Conjunto de regex robustos para detectar XSS, SQLi, SSRF, XXE, brute force, malware e diversos outros ataques, com fallback para modelo de linguagem e cuidado contra ReDoS.
 
 ## Instalação
 


### PR DESCRIPTION
## Summary
- extend regex patterns to cover SSRF, XXE, brute force, phishing, malware and more
- update README to mention expanded detection capabilities

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: connection refused)*
- `python pentest/test_attacks.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68696e96225c832a99446568f1ded894