### PR TITLE
Replace HTML tables with grid layout

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,6 +26,17 @@
             white-space: pre-wrap;
             word-break: break-word;
         }
+        .grid-container { display: flex; flex-direction: column; width: 100%; }
+        .grid-header, .grid-row {
+            display: grid;
+            grid-template-columns: 12ch 8ch 12ch 15ch 8ch 1fr 8ch 8ch 8ch 10ch 12ch;
+            gap: 0.5rem;
+            padding: 0.25rem;
+            align-items: start;
+        }
+        .grid-header { background-color: var(--bs-light); font-weight: bold; }
+        .grid-row:nth-child(odd) { background-color: var(--bs-table-striped-bg); }
+        .grid-row > div { overflow-wrap: anywhere; }
     </style>
 </head>
 <body>

--- a/app/templates/blocked.html
+++ b/app/templates/blocked.html
@@ -5,17 +5,15 @@
 <div class="card">
   <div class="card-body p-0">
     <div class="table-responsive">
-        <table class="table table-sm table-striped table-bordered mb-0" id="blocked-table">
-            <thead class="table-light">
-                <tr>
-                    <th>IP</th>
-                    <th>Status</th>
-                    <th>Motivo</th>
-                    <th>Data/Hora</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
+        <div id="blocked-grid" class="grid-container">
+            <div class="grid-header">
+                <div>IP</div>
+                <div>Status</div>
+                <div>Motivo</div>
+                <div>Data/Hora</div>
+            </div>
+            <div id="blocked-body"></div>
+        </div>
         <div class="d-flex justify-content-between align-items-center p-2">
             <button id="prev-page" class="btn btn-sm btn-secondary">Anterior</button>
             <span id="page-info" class="fw-bold"></span>
@@ -29,15 +27,16 @@
 {% block scripts %}
 <script>
 function addRow(item) {
-    const tbody = document.querySelector('#blocked-table tbody');
-    const tr = document.createElement('tr');
+    const container = document.getElementById('blocked-body');
+    const row = document.createElement('div');
+    row.className = 'grid-row';
     const statusClass = item.status === 'blocked' ? 'status-blocked' : 'status-unblocked';
-    tr.innerHTML = `
-        <td>${item.ip}</td>
-        <td class="${statusClass}">${item.status}</td>
-        <td>${item.reason || ''}</td>
-        <td>${item.blocked_at}</td>`;
-    tbody.prepend(tr);
+    row.innerHTML = `
+        <div>${item.ip}</div>
+        <div class="${statusClass}">${item.status}</div>
+        <div>${item.reason || ''}</div>
+        <div>${item.blocked_at}</div>`;
+    container.prepend(row);
 }
 
 let currentPage = {{ page }};
@@ -46,8 +45,8 @@ let evt;
 async function fetchBlocked(page) {
     const res = await fetch(`/api/blocked?page=${page}`);
     const data = await res.json();
-    const tbody = document.querySelector('#blocked-table tbody');
-    tbody.innerHTML = '';
+    const body = document.getElementById('blocked-body');
+    body.innerHTML = '';
     data.forEach(addRow);
     document.getElementById('page-info').textContent = `Página ${page}`;
     currentPage = page;

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -5,24 +5,22 @@
 <div class="card">
   <div class="card-body p-0">
     <div class="table-responsive">
-        <table class="table table-sm table-striped table-bordered mb-0" id="logs-table">
-            <thead class="table-light">
-                <tr>
-                    <th>Timestamp</th>
-                    <th>Interface</th>
-                    <th>IP</th>
-                    <th>Tipo Ataque</th>
-                    <th>Intensidade</th>
-                    <th>Log</th>
-                    <th>Severity</th>
-                    <th>Anomaly</th>
-                    <th>Ação</th>
-                    <th>Inesperado</th>
-                    <th>Modelos</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
+        <div id="logs-grid" class="grid-container">
+            <div class="grid-header">
+                <div>Timestamp</div>
+                <div>Interface</div>
+                <div>IP</div>
+                <div>Tipo Ataque</div>
+                <div>Intensidade</div>
+                <div>Log</div>
+                <div>Severity</div>
+                <div>Anomaly</div>
+                <div>Ação</div>
+                <div>Inesperado</div>
+                <div>Modelos</div>
+            </div>
+            <div id="logs-body"></div>
+        </div>
         <div class="d-flex justify-content-between align-items-center p-2">
             <button id="prev-page" class="btn btn-sm btn-secondary">Anterior</button>
             <span id="page-info" class="fw-bold"></span>
@@ -49,26 +47,27 @@ function abbreviate(text, len = 60) {
 }
 
 function addLogRow(log) {
-    const tbody = document.querySelector('#logs-table tbody');
-    const tr = document.createElement('tr');
+    const container = document.getElementById('logs-body');
+    const row = document.createElement('div');
+    row.className = 'grid-row';
     const sevClass = log.severity.label ? 'severity-' + log.severity.label.toLowerCase() : '';
     const catStyle = `background-color:${categoryColor(log.nids.label)}`;
     const models = `S:${log.severity.model} A:${log.anomaly.model} N:${log.nids.model}`;
     const ipInfo = log.ip_info ? `${log.ip_info.city || ''}, ${log.ip_info.country || ''}` : '';
     const logLink = `<a href="/log/${log.id}" class="text-decoration-none">${abbreviate(log.log)}</a>`;
-    tr.innerHTML = `
-        <td>${log.created_at}</td>
-        <td>${log.iface}</td>
-        <td title="${ipInfo}">${log.ip || ''}</td>
-        <td>${log.attack_type || log.nids.label}</td>
-        <td>${log.intensity}</td>
-        <td class="log-cell">${logLink}</td>
-        <td class="${sevClass}" title="${log.severity.model}">${log.severity.label}</td>
-        <td title="${log.anomaly.model}">${log.anomaly.label}</td>
-        <td><span class="category-label" style="${catStyle}" title="${log.nids.model}">${log.nids.label}</span></td>
-        <td>${log.semantic.outlier ? 'sim' : 'não'}</td>
-        <td>${models}</td>`;
-    tbody.prepend(tr);
+    row.innerHTML = `
+        <div>${log.created_at}</div>
+        <div>${log.iface}</div>
+        <div title="${ipInfo}">${log.ip || ''}</div>
+        <div>${log.attack_type || log.nids.label}</div>
+        <div>${log.intensity}</div>
+        <div class="log-cell">${logLink}</div>
+        <div class="${sevClass}" title="${log.severity.model}">${log.severity.label}</div>
+        <div title="${log.anomaly.model}">${log.anomaly.label}</div>
+        <div><span class="category-label" style="${catStyle}" title="${log.nids.model}">${log.nids.label}</span></div>
+        <div>${log.semantic.outlier ? 'sim' : 'não'}</div>
+        <div>${models}</div>`;
+    container.prepend(row);
 }
 
 let currentPage = {{ page }};
@@ -77,8 +76,8 @@ let evt;
 async function fetchLogs(page) {
     const res = await fetch(`/api/logs?page=${page}`);
     const data = await res.json();
-    const tbody = document.querySelector('#logs-table tbody');
-    tbody.innerHTML = '';
+    const body = document.getElementById('logs-body');
+    body.innerHTML = '';
     data.forEach(addLogRow);
     document.getElementById('page-info').textContent = `Página ${page}`;
     currentPage = page;


### PR DESCRIPTION
## Summary
- rework Logs and Blocked IPs pages to avoid `<table>` tags
- use CSS grid styles from `base.html`

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68697c433ae0832a933caae618d99eb4