### PR TITLE
Fix Jinja template operators

### DIFF
--- a/app/templates/blocked.html
+++ b/app/templates/blocked.html
@@ -19,7 +19,7 @@
             <tr v-for="item in blocked" :key="item.ip + item.blocked_at">
               <td>{{ item.ip }}</td>
               <td :class="statusClass(item.status)">{{ item.status }}</td>
-              <td>{{ item.reason || '' }}</td>
+              <td>{{ item.reason or '' }}</td>
               <td>{{ item.blocked_at }}</td>
             </tr>
           </tbody>

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -26,8 +26,8 @@
             <tr v-for="log in logs" :key="log.id">
               <td>{{ log.created_at }}</td>
               <td>{{ log.iface }}</td>
-              <td :title="ipInfo(log)">{{ log.ip || '' }}</td>
-              <td>{{ log.attack_type || log.nids.label }}</td>
+              <td :title="ipInfo(log)">{{ log.ip or '' }}</td>
+              <td>{{ log.attack_type or log.nids.label }}</td>
               <td>{{ log.intensity }}</td>
               <td class="log-cell">
                 <a :href="'/log/' + log.id" class="text-decoration-none">{{ abbreviate(log.log) }}</a>


### PR DESCRIPTION
## Summary
- fix invalid `||` operators in Jinja templates

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68698346cffc832aa2bdc28791f06b38