### PR TITLE
Remove unused NIDS model and rely on .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,11 @@ SEMANTIC_MODEL=sentence-transformers/all-MiniLM-L6-v2
 SEVERITY_MODEL=byviz/bylastic_classification_logs
 ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert
 # Comma separated list of NIDS models. The first one is used as primary.
-NIDS_MODELS=caffeinatedcherrychic/mistral-based-NIDS,SilverDragon9/Sniffer.AI
+NIDS_MODELS=SilverDragon9/Sniffer.AI,Dumi2025/log-anomaly-detection-model-roberta
 # Legacy variable for compatibility (optional)
 NIDS_MODEL=
+# Base model used when a NIDS entry contains only LoRA adapters
+NIDS_BASE_MODEL=mistralai/Mistral-7B-v0.1
 
 # Similarity threshold for semantic outlier detection
 SEMANTIC_THRESHOLD=0.5

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
 - Visualização detalhada de cada log com todas as informações classificadas.
 - Barra superior exibe informações resumidas dos modelos carregados.
 - Registro opcional em banco PostgreSQL com esquema definido em `schema.sql`.
-- Suporte a múltiplos modelos NIDS (`caffeinatedcherrychic/mistral-based-NIDS` e
-  `SilverDragon9/Sniffer.AI`) para análise de diferentes tipos de tráfego.
+- Suporte a múltiplos modelos NIDS (`SilverDragon9/Sniffer.AI` e
+  `Dumi2025/log-anomaly-detection-model-roberta`) para análise de diferentes tipos de tráfego.
 - Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
 - Conjunto de regex robustos para detectar XSS, SQLi, SSRF, XXE, brute force, malware e diversos outros ataques, com fallback para modelo de linguagem e cuidado contra ReDoS.
 

--- a/app/config.py
+++ b/app/config.py
@@ -9,34 +9,22 @@ POSTGRES_DB = os.getenv('POSTGRES_DB')
 POSTGRES_HOST = os.getenv('POSTGRES_HOST')
 POSTGRES_PORT = int(os.getenv('POSTGRES_PORT', 5432))
 
-# Provide sensible defaults for the HuggingFace model identifiers so the
-# application can run even if environment variables are missing.
-SEMANTIC_MODEL = os.getenv(
-    'SEMANTIC_MODEL', 'sentence-transformers/all-MiniLM-L6-v2'
-)
-SEVERITY_MODEL = os.getenv(
-    'SEVERITY_MODEL', 'byviz/bylastic_classification_logs'
-)
-ANOMALY_MODEL = os.getenv(
-    'ANOMALY_MODEL', 'teoogherghi/Log-Analysis-Model-DistilBert'
-)
+# Model identifiers are defined only via environment variables
+SEMANTIC_MODEL = os.getenv('SEMANTIC_MODEL')
+SEVERITY_MODEL = os.getenv('SEVERITY_MODEL')
+ANOMALY_MODEL = os.getenv('ANOMALY_MODEL')
 # Allow a list of NIDS models to be configured. If ``NIDS_MODELS`` is not
 # provided, fall back to ``NIDS_MODEL`` or a sensible default.
 NIDS_MODELS = [
-    s.strip() for s in os.getenv(
-        'NIDS_MODELS',
-        'caffeinatedcherrychic/mistral-based-NIDS,SilverDragon9/Sniffer.AI',
-    ).split(',') if s.strip()
+    s.strip() for s in os.getenv('NIDS_MODELS', '').split(',') if s.strip()
 ]
 
 # Backwards compatibility with the old ``NIDS_MODEL`` variable. The first model
 # in ``NIDS_MODELS`` is treated as the primary one.
-NIDS_MODEL = os.getenv(
-    'NIDS_MODEL', NIDS_MODELS[0] if NIDS_MODELS else 'Dumi2025/log-anomaly-detection-model-roberta'
-)
+NIDS_MODEL = os.getenv('NIDS_MODEL', NIDS_MODELS[0] if NIDS_MODELS else None)
 
 # Base model to use when a NIDS entry provides only LoRA adapters
-NIDS_BASE_MODEL = os.getenv('NIDS_BASE_MODEL', 'mistralai/Mistral-7B-v0.1')
+NIDS_BASE_MODEL = os.getenv('NIDS_BASE_MODEL')
 
 SEMANTIC_THRESHOLD = float(os.getenv('SEMANTIC_THRESHOLD', '0.5'))
 BLOCK_SEVERITY_LEVELS = [s.strip().lower() for s in os.getenv('BLOCK_SEVERITY_LEVELS', 'error,high').split(',')]


### PR DESCRIPTION
## Summary
- drop caffeinatedcherrychic model from defaults
- keep only SilverDragon9/Sniffer.AI and Dumi2025/log-anomaly-detection-model-roberta in env example
- centralize model configuration by loading identifiers only from the environment

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686a954bf080832ab9f29f9af582998d