### PR TITLE
Remove default Mistral model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ NIDS_MODELS=SilverDragon9/Sniffer.AI,Dumi2025/log-anomaly-detection-model-robert
 # Legacy variable for compatibility (optional)
 NIDS_MODEL=
 # Base model used when a NIDS entry contains only LoRA adapters
-NIDS_BASE_MODEL=mistralai/Mistral-7B-v0.1
+NIDS_BASE_MODEL=
 
 # Similarity threshold for semantic outlier detection
 SEMANTIC_THRESHOLD=0.5

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Os limiares usados para bloquear IPs podem ser ajustados por variáveis de ambie
 
 - `BLOCK_SEVERITY_LEVELS` &ndash; níveis de severidade que resultam em bloqueio imediato (padrão `error,high`).
 - `BLOCK_ANOMALY_THRESHOLD` &ndash; probabilidade mínima de anomalia para bloquear quando o evento também é considerado *outlier* semântico (padrão `0.5`).
-- `NIDS_BASE_MODEL` &ndash; modelo base a ser usado quando um item de `NIDS_MODELS` contém apenas adaptadores LoRA (padrão `mistralai/Mistral-7B-v0.1`).
+- `NIDS_BASE_MODEL` &ndash; modelo base a ser usado quando um item de `NIDS_MODELS` contém apenas adaptadores LoRA.
 
 ## Banco de dados
 


### PR DESCRIPTION
## Summary
- remove mentions of `mistralai/Mistral-7B-v0.1`
- leave `NIDS_BASE_MODEL` unset in `.env.example`

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686a989252fc832abae865fc0ecbb52a