### PR TITLE
Remove regex attack detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
 - Suporte a múltiplos modelos NIDS (`SilverDragon9/Sniffer.AI` e
   `Dumi2025/log-anomaly-detection-model-roberta`) para análise de diferentes tipos de tráfego.
 - Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
-- Conjunto de regex robustos para detectar XSS, SQLi, SSRF, XXE, brute force, malware e diversos outros ataques, com fallback para modelo de linguagem e cuidado contra ReDoS.
+- Classificação de ataques realizada apenas por modelos de linguagem, sem regex.
 
 ## Instalação
 

--- a/app/attack_classifier.py
+++ b/app/attack_classifier.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 
 THRESHOLD = int(os.getenv("ATTACK_SIZE_THRESHOLD", "1000"))
@@ -10,68 +9,10 @@ def ml_multiclass_predict(text: str) -> str:
     return "normal"
 
 
-def _load_patterns():
-    # Regex based on common attack patterns documented by OWASP and other
-    # security references. Designed to avoid catastrophic backtracking.
-    return [
-        # SQL Injection
-        (
-            re.compile(
-                r"(\%27)|(')|(--)|(\%23)|(#)|\b(select|insert|update|delete|union|drop|exec|declare)\b",
-                re.I,
-            ),
-            "sql_injection",
-        ),
-        # XSS (tags with javascript expressions)
-        (
-            re.compile(
-                r"<\s*(script|img|iframe|svg)[^>]*(src|onerror|onload|javascript|alert)\s*=",
-                re.I,
-            ),
-            "xss",
-        ),
-        # SSRF – unexpected URLs in input
-        (re.compile(r"\b(http|https|ftp):\/\/[^\s\"]+", re.I), "ssrf"),
-        # XXE – external entity declaration
-        (re.compile(r"<!DOCTYPE\s+[^>]*ENTITY\s+SYSTEM", re.I), "xxe"),
-        # Path Traversal – ../ or encoded variants
-        (re.compile(r"(\.\./|\.\.\\|%2e%2e/)", re.I), "path_traversal"),
-        # Command Injection – shell metacharacters
-        (re.compile(r"[;&|`]|/(bin/)?(bash|sh|cat)\b", re.I), "command_injection"),
-        # File Inclusion
-        (
-            re.compile(r"\b(include|require|php://|file://|ftp://)\b", re.I),
-            "file_inclusion",
-        ),
-        # Open Redirect
-        (re.compile(r"(redirect|url|next)=https?:\/\/[^\s\"]+", re.I), "open_redirect"),
-        # Header or CRLF Injection
-        (re.compile(r"(\r\n|\r|\n|%0d|%0a)", re.I), "header_injection"),
-        # Credential stuffing / brute force
-        (re.compile(r"(?:(?:failed)\s+login|\bauthentication\s+failed\b)", re.I), "brute_force"),
-        # Phishing keywords followed by a link
-        (re.compile(r"\b(click\s+here|account|verify|update|login)\b.*(http|https):\/\/", re.I), "phishing"),
-        # Botnet or malware command lines
-        (re.compile(r"\brundll32\.exe\s+\\\S{10,70}\.\S{10,70},\w{16}\b", re.I), "malware_botnet"),
-        # Ransomware/Trojan words in logs
-        (re.compile(r"\b(encrypt(ed)?|crypt|ransom|payload|C&C|botnet)\b", re.I), "malware_ransomware"),
-        # IoT or emerging attack patterns
-        (re.compile(r"\b(Mirai|botnet|CVE-\d{4}-\d{4,7})\b", re.I), "emerging_iot_attack"),
-        # Slowloris / DoS keywords
-        (re.compile(r"\bSlowloris\b", re.I), "dos"),
-        # Hidden field tampering
-        (re.compile(r"hidden\s*=\s*['\"]?\w+['\"]?", re.I), "form_tampering"),
-    ]
-
-
-PATTERNS = _load_patterns()
 
 
 def classify(text: str) -> str:
     """Classify the text into an attack category."""
-    for pattern, label in PATTERNS:
-        if pattern.search(text):
-            return label
     if len(text) > THRESHOLD:
         return "dos"
     return ml_multiclass_predict(text)


### PR DESCRIPTION
## Summary
- drop regex pattern detection to rely solely on ML models
- update README to note the new approach

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: connection refused)*
- `python pentest/test_attacks.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686ae2b18b84832a9b5ef781fc83ee33