### PR TITLE
Fix Elasticsearch client version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
    ```bash
    pip install -r requirements.txt
    ```
+   O arquivo já fixa `elasticsearch` na versão 8.x para manter compatibilidade
+   com clusters Elasticsearch 7 ou 8.
 3. (Opcional) Suba o contêiner do Nginx Unit e da aplicação de exemplo:
    ```bash
    docker-compose up -d

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ bitsandbytes
 peft
 pandas
 joblib
-elasticsearch
+elasticsearch>=8,<9


### PR DESCRIPTION
## Summary
- pin `elasticsearch` dependency to version 8.x
- note pinned version in the README

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: connection refused)*
- `python pentest/test_attacks.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686afb1d89d8832a93376e95def760a7