### PR TITLE
Use OpenSearch container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@ POSTGRES_DB=nginx_unit_ia
 POSTGRES_HOST=
 POSTGRES_PORT=5432
 
-# Elasticsearch (community edition) connection URL
-ES_HOST=http://elasticsearch:9200
+# OpenSearch connection URL
+ES_HOST=http://opensearch:9200
 # Optional credentials if security is enabled
 ES_USER=
 ES_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
 - Embeddings gerados com `sentence-transformers/all-MiniLM-L6-v2` e
   classificação/anomalias usando `teoogherghi/Log-Analysis-Model-DistilBert`.
 - Registro opcional em banco PostgreSQL com esquema definido em `schema.sql`.
-- Integração opcional com Elasticsearch para indexar logs e IPs bloqueados.
+- Integração opcional com OpenSearch para indexar logs e IPs bloqueados.
 - Suporte a múltiplos modelos NIDS (`SilverDragon9/Sniffer.AI` e
   `Dumi2025/log-anomaly-detection-model-roberta`) para análise de diferentes tipos de tráfego.
 - Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
@@ -29,8 +29,8 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
    ```bash
    pip install -r requirements.txt
    ```
-   O arquivo já fixa `elasticsearch` na versão 8.x para manter compatibilidade
-   com clusters Elasticsearch 7 ou 8.
+   O arquivo já inclui `opensearch-py` na versão 2.x para manter compatibilidade
+   com o OpenSearch 2.
 3. (Opcional) Suba o contêiner do Nginx Unit e da aplicação de exemplo:
    ```bash
    docker-compose up -d
@@ -69,7 +69,7 @@ Os limiares usados para bloquear IPs podem ser ajustados por variáveis de ambie
 
 Defina `POSTGRES_HOST` e as demais variáveis de conexão para ativar o uso de PostgreSQL. Caso contrário, o proxy funciona sem dependência de banco, apenas registrando em arquivo.
 
-Além disso, é possível enviar os registros para um cluster Elasticsearch (versão comunidade). Configure `ES_HOST` com a URL do servidor e, opcionalmente, `ES_USER`/`ES_PASSWORD` caso a autenticação esteja habilitada. Os documentos são indexados nos índices `logs` e `blocked_ips` para facilitar buscas e visualizações via Kibana ou ferramentas compatíveis.
+Além disso, é possível enviar os registros para um cluster OpenSearch (versão comunidade). Configure `ES_HOST` com a URL do servidor e, opcionalmente, `ES_USER`/`ES_PASSWORD` caso a autenticação esteja habilitada. Os documentos são indexados nos índices `logs` e `blocked_ips` para facilitar buscas e visualizações via Kibana ou ferramentas compatíveis.
 
 ## Pentest e testes
 

--- a/app/es.py
+++ b/app/es.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 import os
 from typing import Optional
 
-from elasticsearch import Elasticsearch
+from opensearchpy import OpenSearch
 from . import config
 
-client: Optional[Elasticsearch] = None
+client: Optional[OpenSearch] = None
 
 if config.ES_HOST:
     es_kwargs = {"hosts": [config.ES_HOST]}
     if config.ES_USER and config.ES_PASSWORD:
         es_kwargs["basic_auth"] = (config.ES_USER, config.ES_PASSWORD)
-    client = Elasticsearch(**es_kwargs)
+    client = OpenSearch(**es_kwargs)
 
 
 def index_log(doc: dict) -> None:
-    """Index a log document into Elasticsearch."""
+    """Index a log document into OpenSearch."""
     if client is None:
         return
     try:
@@ -28,7 +28,7 @@ def index_log(doc: dict) -> None:
 
 
 def index_blocked_ip(doc: dict) -> None:
-    """Index blocked IP info into Elasticsearch."""
+    """Index blocked IP info into OpenSearch."""
     if client is None:
         return
     try:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,15 +15,15 @@ services:
     ports:
       - "8000:8000"
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+  opensearch:
+    image: opensearchproject/opensearch:2.15.0
     environment:
       - discovery.type=single-node
-      - xpack.security.enabled=false
+      - plugins.security.disabled=true
     ports:
       - "9200:9200"
     volumes:
-      - esdata:/usr/share/elasticsearch/data
+      - esdata:/usr/share/opensearch/data
 
 volumes:
   esdata:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ bitsandbytes
 peft
 pandas
 joblib
-elasticsearch>=8,<9
+opensearch-py>=2,<3


### PR DESCRIPTION
## Summary
- switch docker-compose service to `opensearchproject/opensearch:2.15.0`
- update environment example for OpenSearch
- depend on `opensearch-py` in requirements
- use OpenSearch client in `app/es.py`
- update README accordingly

## Testing
- `python pentest/test_structure.py`

------
https://chatgpt.com/codex/tasks/task_e_686afeaa57e8832a99a39b0c45708f5a