### PR TITLE
Fix OpenSearch index parameter

### DIFF
--- a/app/es.py
+++ b/app/es.py
@@ -19,7 +19,7 @@ def index_log(doc: dict) -> None:
     if client is None:
         return
     try:
-        client.index(index="logs", document=doc)
+        client.index(index="logs", body=doc)
     except Exception as exc:
         # ignore indexing errors but log them for debugging
         import logging
@@ -32,7 +32,7 @@ def index_blocked_ip(doc: dict) -> None:
     if client is None:
         return
     try:
-        client.index(index="blocked_ips", document=doc)
+        client.index(index="blocked_ips", body=doc)
     except Exception as exc:
         import logging
 


### PR DESCRIPTION
## Summary
- fix unexpected keyword argument error when indexing documents into OpenSearch

## Testing
- `python pentest/test_structure.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b01720450832abef982b6b3e645ad