### PR TITLE
Add OpenSearch credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,10 @@ POSTGRES_PORT=5432
 # OpenSearch connection URL
 ES_HOST=http://opensearch:9200
 # Optional credentials if security is enabled
-ES_USER=
-ES_PASSWORD=
+ES_USER=admin
+ES_PASSWORD=admin
+# Initial admin password for the OpenSearch container
+OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
 
 # Semantic model path
 SEMANTIC_MODEL=sentence-transformers/all-MiniLM-L6-v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       - discovery.type=single-node
       - plugins.security.disabled=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}
     ports:
       - "9200:9200"
     volumes:


### PR DESCRIPTION
## Summary
- set default OpenSearch credentials in `.env.example`
- pass `OPENSEARCH_INITIAL_ADMIN_PASSWORD` to the opensearch container

## Testing
- `python pentest/test_structure.py`

------
https://chatgpt.com/codex/tasks/task_e_686b04300570832aa9e53d7c0fb07a08