### PR TITLE
Fix Unit container missing Python deps

### DIFF
--- a/Dockerfile.unit
+++ b/Dockerfile.unit
@@ -1,0 +1,3 @@
+FROM nginx/unit:1.29.1-python3.11
+COPY requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
    com o OpenSearch 2.
 3. (Opcional) Suba o contêiner do Nginx Unit e da aplicação de exemplo:
    ```bash
-   docker-compose up -d
+   docker-compose up -d --build
    ```
+   O compose irá montar a aplicação e instalar as dependências usando o arquivo
+   `Dockerfile.unit`.
 
 ## Uso
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3.8'
 services:
   unit:
-    image: nginx/unit:1.29.1-python3.11
+    build:
+      context: .
+      dockerfile: Dockerfile.unit
     volumes:
       - ./app:/www/app
       - ./unit-config.json:/docker-entrypoint.d/unit-config.json


### PR DESCRIPTION
## Summary
- install Python packages inside the Unit service
- build the Unit service using Dockerfile.unit
- mention the new build step in docs

## Testing
- `python pentest/test_structure.py`

------
https://chatgpt.com/codex/tasks/task_e_686b08f43324832ab93eaf616752bc56