### PR TITLE
Fix Unit application import path

### DIFF
--- a/unit-config.json
+++ b/unit-config.json
@@ -7,8 +7,8 @@
     "applications": {
         "dummy": {
             "type": "python",
-            "path": "/www/app",
-            "module": "wsgi"
+            "path": "/www",
+            "module": "app.wsgi"
         }
     },
     "routes": [


### PR DESCRIPTION
## Summary
- adjust module and path in unit-config to load `app.wsgi`

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686b0ae2cfc0832abe52db4468a50416