### PR TITLE
Fix HF token permissions

### DIFF
--- a/Dockerfile.unit
+++ b/Dockerfile.unit
@@ -1,3 +1,8 @@
 FROM nginx/unit:1.29.1-python3.11
+
+# Use a writable location for HuggingFace caches to avoid permission errors
+ENV HF_HOME=/tmp/huggingface
+RUN mkdir -p "$HF_HOME" && chown unit:unit "$HF_HOME"
+
 COPY requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
    docker-compose up -d --build
    ```
    O compose irá montar a aplicação e instalar as dependências usando o arquivo
-   `Dockerfile.unit`.
+   `Dockerfile.unit`. Esse Dockerfile define a variável `HF_HOME` como
+   `/tmp/huggingface` para que o usuário "unit" tenha permissão de escrita no
+   cache do Hugging Face e evite erros ao baixar modelos.
 
 ## Uso
 


### PR DESCRIPTION
## Summary
- handle HuggingFace cache permissions in Dockerfile.unit
- document HF_HOME in README

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: connection refused)*
- `python pentest/test_attacks.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686b151d1380832a9da7d084cdccfadf