### PR TITLE
Add default model identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
 ## Instalação
 
 1. Copie `.env.example` para `.env` e ajuste as variáveis conforme o ambiente.
+   Caso o arquivo `.env` não exista, a aplicação utilizará valores padrão para
+   os modelos, conforme definidos em `app/config.py`.
 2. Instale as dependências do Python:
    ```bash
    pip install -r requirements.txt

--- a/app/config.py
+++ b/app/config.py
@@ -15,13 +15,28 @@ ES_USER = os.getenv('ES_USER')
 ES_PASSWORD = os.getenv('ES_PASSWORD')
 
 # Model identifiers are defined only via environment variables
-SEMANTIC_MODEL = os.getenv('SEMANTIC_MODEL')
-SEVERITY_MODEL = os.getenv('SEVERITY_MODEL')
-ANOMALY_MODEL = os.getenv('ANOMALY_MODEL')
+# Provide sensible defaults so the application can start even when the
+# environment file is missing. These match the values defined in
+# ``.env.example`` and allow running the container without additional
+# configuration.
+SEMANTIC_MODEL = os.getenv(
+    'SEMANTIC_MODEL', 'sentence-transformers/all-MiniLM-L6-v2'
+)
+SEVERITY_MODEL = os.getenv(
+    'SEVERITY_MODEL', 'byviz/bylastic_classification_logs'
+)
+ANOMALY_MODEL = os.getenv(
+    'ANOMALY_MODEL', 'teoogherghi/Log-Analysis-Model-DistilBert'
+)
 # Allow a list of NIDS models to be configured. If ``NIDS_MODELS`` is not
 # provided, fall back to ``NIDS_MODEL`` or a sensible default.
 NIDS_MODELS = [
-    s.strip() for s in os.getenv('NIDS_MODELS', '').split(',') if s.strip()
+    s.strip()
+    for s in os.getenv(
+        'NIDS_MODELS',
+        'SilverDragon9/Sniffer.AI,Dumi2025/log-anomaly-detection-model-roberta',
+    ).split(',')
+    if s.strip()
 ]
 
 # Backwards compatibility with the old ``NIDS_MODEL`` variable. The first model


### PR DESCRIPTION
## Summary
- use default model IDs if environment variables aren't set
- document that `.env` is optional and defaults exist

## Testing
- `python pentest/test_structure.py`

------
https://chatgpt.com/codex/tasks/task_e_686bd4cfadf4832aaffde4333364c848