### PR TITLE
Use Sniffer.AI classification in panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
   classificação/anomalias usando `teoogherghi/Log-Analysis-Model-DistilBert`.
 - Registro opcional em banco PostgreSQL com esquema definido em `schema.sql`.
 - Integração opcional com OpenSearch para indexar logs e IPs bloqueados.
-- Suporte a múltiplos modelos NIDS (`SilverDragon9/Sniffer.AI` e
-  `Dumi2025/log-anomaly-detection-model-roberta`) para análise de diferentes tipos de tráfego.
+- Tipo de ataque sempre classificado com o IDS `SilverDragon9/Sniffer.AI`; outros modelos NIDS podem complementar a análise.
 - Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
 - Classificação de ataques realizada apenas por modelos de linguagem, sem regex.
-- Coluna **Ação** do painel exibe a categoria retornada pelos modelos NIDS configurados.
+- Coluna **Sniffer.AI** exibe o tipo de ataque retornado por esse IDS e a coluna **Categoria** mostra a maioria dos demais modelos.
 
 ## Instalação
 
@@ -96,7 +95,8 @@ O proxy também monitora a quantidade de requisições de cada IP e bloqueia aut
 
 ### Sniffer.AI em tempo real
 
-O IDS Sniffer.AI é opcional e pode ser utilizado em duas formas. A classe
+O IDS Sniffer.AI é utilizado pela aplicação para classificar o tipo de ataque,
+mas também pode ser executado de forma independente. A classe
 `HFTextSniffer` carrega o modelo do Hugging Face via Transformers enquanto a
 classe `Sniffer` utiliza os artefatos `.pkl` originais. Ambos aceitam linhas de
 log no formato JSON ou `chave=valor` e permitem monitorar arquivos em tempo

--- a/app/templates/log_detail.html
+++ b/app/templates/log_detail.html
@@ -8,12 +8,12 @@
     <p><strong>Timestamp:</strong> {{ log.created_at }}</p>
     <p><strong>Interface:</strong> {{ log.iface }}</p>
     <p><strong>IP:</strong> {{ log.ip }}</p>
-    <p><strong>Tipo Ataque:</strong> {{ log.attack_type }}</p>
+    <p><strong>Sniffer.AI:</strong> {{ log.attack_type }}</p>
     <p><strong>Intensidade:</strong> {{ intensity }}</p>
     <pre class="mt-3">{{ log.log }}</pre>
     <p><strong>Severity:</strong> {{ log.severity.label }}</p>
     <p><strong>Anomaly:</strong> {{ log.anomaly.label }}</p>
-    <p><strong>Categoria:</strong> {{ log.nids.label }}</p>
+    <p><strong>Categoria:</strong> {{ log.category }}</p>
     <p><strong>Similaridade:</strong> {{ log.semantic.similarity }}</p>
     <p><strong>Modelos:</strong> S: {{ log.severity.model }} | A: {{ log.anomaly.model }} | N: {{ log.nids.model }}</p>
   </div>

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -12,12 +12,12 @@
               <th>Timestamp</th>
               <th>Interface</th>
               <th>IP</th>
-              <th>Tipo Ataque</th>
+              <th>Sniffer.AI</th>
               <th>Intensidade</th>
               <th>Log</th>
               <th>Severity</th>
               <th>Anomaly</th>
-              <th>Ação</th>
+              <th>Categoria</th>
               <th>Inesperado</th>
               <th>Modelos</th>
             </tr>
@@ -79,12 +79,12 @@ function renderLogs() {
             <td>${log.created_at}</td>
             <td>${log.iface}</td>
             <td title="${ipInfo(log)}">${log.ip || ''}</td>
-            <td>${log.attack_type || log.nids.label}</td>
+            <td>${log.attack_type}</td>
             <td>${log.intensity}</td>
             <td class="log-cell"><a href="/log/${log.id}" class="text-decoration-none">${abbreviate(log.log)}</a></td>
             <td class="${severityClass(log.severity.label)}" title="${log.severity.model}">${log.severity.label}</td>
             <td title="${log.anomaly.model}">${log.anomaly.label}</td>
-            <td><span class="category-label" style="background-color:${categoryColor(log.nids.label)}" title="${log.nids.model}">${log.nids.label}</span></td>
+            <td><span class="category-label" style="background-color:${categoryColor(log.category)}" title="${log.nids.model}">${log.category}</span></td>
             <td>${log.semantic.outlier ? 'sim' : 'não'}</td>
             <td>${modelInfo(log)}</td>`;
         tbody.appendChild(tr);

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -99,6 +99,7 @@ def analyze_request() -> dict:
         'anomaly': result['anomaly'],
         'nids': result['nids'],
         'attack_type': attack_type,
+        'category': result['nids'].get('majority', result['nids']['label']),
         'semantic': result['semantic'],
         'intensity': result['intensity'],
     })
@@ -113,6 +114,7 @@ def analyze_request() -> dict:
         'anomaly': result['anomaly'],
         'nids': result['nids'],
         'attack_type': attack_type,
+        'category': result['nids'].get('majority', result['nids']['label']),
         'semantic': result['semantic'],
         'intensity': result['intensity'],
     })
@@ -181,6 +183,7 @@ def logs():
     logs = db.get_logs(limit=100, offset=(page - 1) * 100)
     for item in logs:
         item['attack_type'] = item.get('attack_type') or item['nids']['label']
+        item['category'] = item['nids'].get('majority', item['nids']['label'])
         item['intensity'] = detection.calculate_intensity(
             item['severity']['label'],
             item['anomaly']['score'],
@@ -201,6 +204,7 @@ def log_detail(log_id: int):
     if not log:
         return 'Log não encontrado', 404
     log['attack_type'] = log.get('attack_type') or log['nids']['label']
+    log['category'] = log['nids'].get('majority', log['nids']['label'])
     intensity = detection.calculate_intensity(
         log['severity']['label'],
         log['anomaly']['score'],
@@ -244,6 +248,7 @@ def api_logs():
             'anomaly': log['anomaly'],
             'nids': log['nids'],
             'attack_type': log.get('attack_type') or log['nids']['label'],
+            'category': log['nids'].get('majority', log['nids']['label']),
             'semantic': log.get('semantic'),
             'intensity': intensity,
         })


### PR DESCRIPTION
## Summary
- rely on Sniffer.AI for attack classification
- expose Sniffer result and majority label in log API and SSE
- display Sniffer.AI and aggregated category on the web panel
- document Sniffer.AI as mandatory IDS

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686bdf0f0ae0832aa33d4861ca131892