### PR TITLE
Improve HTTP attack detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ SEMANTIC_MODEL=sentence-transformers/all-MiniLM-L6-v2
 SEVERITY_MODEL=byviz/bylastic_classification_logs
 ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert
 # Comma separated list of NIDS models. The first one is used as primary.
-NIDS_MODELS=SilverDragon9/Sniffer.AI,Dumi2025/log-anomaly-detection-model-roberta
+NIDS_MODELS=maleke01/RoBERTa-WebAttack,SilverDragon9/Sniffer.AI,Dumi2025/log-anomaly-detection-model-roberta
 # Legacy variable for compatibility (optional)
 NIDS_MODEL=
 # Base model used when a NIDS entry contains only LoRA adapters

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
   classificação/anomalias usando `teoogherghi/Log-Analysis-Model-DistilBert`.
 - Registro opcional em banco PostgreSQL com esquema definido em `schema.sql`.
 - Integração opcional com OpenSearch para indexar logs e IPs bloqueados.
-- Tipo de ataque sempre classificado com o IDS `SilverDragon9/Sniffer.AI`; outros modelos NIDS podem complementar a análise.
+- Tipo de ataque classificado por padrão com `maleke01/RoBERTa-WebAttack`; outros modelos NIDS podem complementar a análise.
 - Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
 - Classificação de ataques realizada apenas por modelos de linguagem, sem regex.
-- Coluna **Sniffer.AI** exibe o tipo de ataque retornado por esse IDS e a coluna **Categoria** mostra a maioria dos demais modelos.
+- A coluna **Principal** exibe o tipo de ataque retornado pelo modelo definido como primário e **Categoria** mostra a maioria dos demais modelos.
 
 ## Instalação
 
@@ -95,8 +95,7 @@ O proxy também monitora a quantidade de requisições de cada IP e bloqueia aut
 
 ### Sniffer.AI em tempo real
 
-O IDS Sniffer.AI é utilizado pela aplicação para classificar o tipo de ataque,
-mas também pode ser executado de forma independente. A classe
+O modelo Sniffer.AI continua disponível e pode ser utilizado de forma independente para logs de IoT. A classe
 `HFTextSniffer` carrega o modelo do Hugging Face via Transformers enquanto a
 classe `Sniffer` utiliza os artefatos `.pkl` originais. Ambos aceitam linhas de
 log no formato JSON ou `chave=valor` e permitem monitorar arquivos em tempo

--- a/app/config.py
+++ b/app/config.py
@@ -34,7 +34,7 @@ NIDS_MODELS = [
     s.strip()
     for s in os.getenv(
         'NIDS_MODELS',
-        'SilverDragon9/Sniffer.AI,Dumi2025/log-anomaly-detection-model-roberta',
+        'maleke01/RoBERTa-WebAttack,SilverDragon9/Sniffer.AI,Dumi2025/log-anomaly-detection-model-roberta',
     ).split(',')
     if s.strip()
 ]

--- a/app/templates/log_detail.html
+++ b/app/templates/log_detail.html
@@ -8,7 +8,7 @@
     <p><strong>Timestamp:</strong> {{ log.created_at }}</p>
     <p><strong>Interface:</strong> {{ log.iface }}</p>
     <p><strong>IP:</strong> {{ log.ip }}</p>
-    <p><strong>Sniffer.AI:</strong> {{ log.attack_type }}</p>
+    <p><strong>Principal:</strong> {{ log.attack_type }}</p>
     <p><strong>Intensidade:</strong> {{ intensity }}</p>
     <pre class="mt-3">{{ log.log }}</pre>
     <p><strong>Severity:</strong> {{ log.severity.label }}</p>

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -12,7 +12,7 @@
               <th>Timestamp</th>
               <th>Interface</th>
               <th>IP</th>
-              <th>Sniffer.AI</th>
+              <th>Principal</th>
               <th>Intensidade</th>
               <th>Log</th>
               <th>Severity</th>


### PR DESCRIPTION
## Summary
- add HTTP web attack model to default NIDS list
- generalize primary NIDS selection in detector
- rename Sniffer.AI column to "Principal" in templates
- update docs and env example for new defaults

## Testing
- `pytest -q`
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686be1c28e80832ab37ffa6cc882209d