### PR TITLE
Replace SnifferAI with HTTP attack models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ SEMANTIC_MODEL=sentence-transformers/all-MiniLM-L6-v2
 SEVERITY_MODEL=byviz/bylastic_classification_logs
 ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert
 # Comma separated list of NIDS models. The first one is used as primary.
-NIDS_MODELS=maleke01/RoBERTa-WebAttack,SilverDragon9/Sniffer.AI,Dumi2025/log-anomaly-detection-model-roberta
+NIDS_MODELS=maleke01/RoBERTa-WebAttack,Canstralian/CyberAttackDetection,maheshj01/sql-injection-classifier,Dumi2025/log-anomaly-detection-model-roberta
 # Legacy variable for compatibility (optional)
 NIDS_MODEL=
 # Base model used when a NIDS entry contains only LoRA adapters

--- a/README.md
+++ b/README.md
@@ -93,22 +93,13 @@ O painel web possui a página `http://localhost:8080/blocked` que exibe todos os
 Sempre que essa página é acessada, a lista é sincronizada com as regras atuais do UFW, garantindo que o banco reflita o estado real do firewall.
 O proxy também monitora a quantidade de requisições de cada IP e bloqueia automaticamente padrões que indiquem ataques de negação de serviço.
 
-### Sniffer.AI em tempo real
+### Modelos para tráfego HTTP
 
-O modelo Sniffer.AI continua disponível e pode ser utilizado de forma independente para logs de IoT. A classe
-`HFTextSniffer` carrega o modelo do Hugging Face via Transformers enquanto a
-classe `Sniffer` utiliza os artefatos `.pkl` originais. Ambos aceitam linhas de
-log no formato JSON ou `chave=valor` e permitem monitorar arquivos em tempo
-real:
-
-```python
-from app.sniffer_ai.hf_sniffer import HFTextSniffer
-
-sniffer = HFTextSniffer()
-for line in sniffer.stream_file('/var/log/iot.log'):
-    label, scores = sniffer.predict_from_text(line)
-    print(label, scores)
-```
+Esta versão utiliza modelos mais adequados para identificar ataques em requisições web.
+O classificador binário [`Canstralian/CyberAttackDetection`](https://huggingface.co/Canstralian/CyberAttackDetection)
+distingue tráfego legítimo de potenciais ataques, enquanto
+[`maheshj01/sql-injection-classifier`](https://huggingface.co/maheshj01/sql-injection-classifier)
+identifica consultas com SQL Injection. Ambos são definidos na variável `NIDS_MODELS` e são carregados automaticamente.
 
 ### Whitelist
 

--- a/app/config.py
+++ b/app/config.py
@@ -34,7 +34,7 @@ NIDS_MODELS = [
     s.strip()
     for s in os.getenv(
         'NIDS_MODELS',
-        'maleke01/RoBERTa-WebAttack,SilverDragon9/Sniffer.AI,Dumi2025/log-anomaly-detection-model-roberta',
+        'maleke01/RoBERTa-WebAttack,Canstralian/CyberAttackDetection,maheshj01/sql-injection-classifier,Dumi2025/log-anomaly-detection-model-roberta',
     ).split(',')
     if s.strip()
 ]

--- a/app/preload.py
+++ b/app/preload.py
@@ -22,13 +22,6 @@ def download_models() -> None:
                 AutoModelForSequenceClassification.from_pretrained(model_name)
         except Exception as exc:
             logger.error("Erro ao baixar %s: %s", model_name, exc)
-            if model_name == "SilverDragon9/Sniffer.AI":
-                try:
-                    from .sniffer_ai import Sniffer
-
-                    Sniffer()
-                except Exception as exc2:
-                    logger.error("Falha ao baixar modelos Sniffer.AI: %s", exc2)
     try:
         SentenceTransformer(config.SEMANTIC_MODEL)
     except Exception as exc:


### PR DESCRIPTION
## Summary
- switch default NIDS models to CyberAttackDetection and sql-injection-classifier
- remove Sniffer.AI specific handling in model loader
- update preload utilities
- document new HTTP models

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686be67b6b24832abc2bf84464136af3