### PR TITLE
Fix NIDS model selection when env vars empty

### DIFF
--- a/app/detection.py
+++ b/app/detection.py
@@ -45,7 +45,17 @@ class Detector:
         # para determinar o tipo de ataque das requisições. Ele pode ser qualquer
         # classificador compatível com Transformers.
         self.nids_models = []
-        self.primary_name = config.NIDS_MODELS[0] if config.NIDS_MODELS else "Canstralian/CyberAttackDetection"
+        # Permite usar ``NIDS_MODEL`` para especificar o classificador principal.
+        # Caso esteja vazio, recorre ao primeiro item de ``NIDS_MODELS`` ou a um
+        # valor padrao. Isso evita que ``None`` seja passado para
+        # ``from_pretrained``.
+        if getattr(config, "NIDS_MODEL", None):
+            name = config.NIDS_MODEL.strip()
+        else:
+            name = ""
+        if not name:
+            name = config.NIDS_MODELS[0] if config.NIDS_MODELS else "Canstralian/CyberAttackDetection"
+        self.primary_name = name
         self.primary = None
         self.primary_tok = None
         try:


### PR DESCRIPTION
## Summary
- fix handling of empty `NIDS_MODEL` so the first entry in `NIDS_MODELS` is used

## Testing
- `python3 pentest/test_structure.py`
- `python3 pentest/test_attacks.py` *(fails: connection refused)*
- `python3 pentest/test_security.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686bea8e9760832ab9c49356a0dcc95a