### PR TITLE
Support HF models with remote code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ SEMANTIC_MODEL=sentence-transformers/all-MiniLM-L6-v2
 SEVERITY_MODEL=byviz/bylastic_classification_logs
 ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert
 # Comma separated list of NIDS models. The first one is used as primary.
+# Comma separated list of NIDS models. Custom repos com código próprio são
+# suportados com `trust_remote_code` habilitado.
 NIDS_MODELS=Canstralian/CyberAttackDetection
 # Legacy variable for compatibility (optional)
 NIDS_MODEL=

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
 - Barra superior exibe informações resumidas dos modelos carregados.
 - Embeddings e classificação/anomalias realizados pelos modelos definidos
   nas variáveis `SEMANTIC_MODEL` e `ANOMALY_MODEL` do arquivo `.env`.
+- Suporte a modelos com implementações personalizadas do Hugging Face via
+  `trust_remote_code` quando especificados em `.env`.
 - Registro opcional em banco PostgreSQL com esquema definido em `schema.sql`.
 - Integração opcional com OpenSearch para indexar logs e IPs bloqueados.
 - O tipo de ataque é classificado utilizando o(s) modelo(s) definido(s)

--- a/app/detection.py
+++ b/app/detection.py
@@ -37,10 +37,22 @@ class Detector:
         logger.info("Carregando modelos em %s", device)
         self.device = torch.device(device)
 
-        self.severity_tokenizer = AutoTokenizer.from_pretrained(config.SEVERITY_MODEL)
-        self.severity_model = AutoModelForSequenceClassification.from_pretrained(config.SEVERITY_MODEL).to(self.device)
-        self.anomaly_tokenizer = AutoTokenizer.from_pretrained(config.ANOMALY_MODEL)
-        self.anomaly_model = AutoModelForSequenceClassification.from_pretrained(config.ANOMALY_MODEL).to(self.device)
+        self.severity_tokenizer = AutoTokenizer.from_pretrained(
+            config.SEVERITY_MODEL,
+            trust_remote_code=True,
+        )
+        self.severity_model = AutoModelForSequenceClassification.from_pretrained(
+            config.SEVERITY_MODEL,
+            trust_remote_code=True,
+        ).to(self.device)
+        self.anomaly_tokenizer = AutoTokenizer.from_pretrained(
+            config.ANOMALY_MODEL,
+            trust_remote_code=True,
+        )
+        self.anomaly_model = AutoModelForSequenceClassification.from_pretrained(
+            config.ANOMALY_MODEL,
+            trust_remote_code=True,
+        ).to(self.device)
         # O primeiro item de ``NIDS_MODELS`` é tratado como modelo principal
         # para determinar o tipo de ataque das requisições. Ele pode ser qualquer
         # classificador compatível com Transformers.
@@ -61,8 +73,14 @@ class Detector:
         self.primary = None
         self.primary_tok = None
         try:
-            self.primary_tok = AutoTokenizer.from_pretrained(self.primary_name)
-            self.primary = AutoModelForSequenceClassification.from_pretrained(self.primary_name).to(self.device)
+            self.primary_tok = AutoTokenizer.from_pretrained(
+                self.primary_name,
+                trust_remote_code=True,
+            )
+            self.primary = AutoModelForSequenceClassification.from_pretrained(
+                self.primary_name,
+                trust_remote_code=True,
+            ).to(self.device)
         except OSError:
             base_name = config.NIDS_BASE_MODEL or "distilbert-base-uncased"
             logger.info(
@@ -70,14 +88,26 @@ class Detector:
                 self.primary_name,
                 base_name,
             )
-            self.primary_tok = AutoTokenizer.from_pretrained(base_name)
-            base = AutoModelForSequenceClassification.from_pretrained(base_name)
+            self.primary_tok = AutoTokenizer.from_pretrained(
+                base_name,
+                trust_remote_code=True,
+            )
+            base = AutoModelForSequenceClassification.from_pretrained(
+                base_name,
+                trust_remote_code=True,
+            )
             self.primary = PeftModel.from_pretrained(base, self.primary_name).to(self.device)
 
         for model_name in config.NIDS_MODELS[1:]:
             try:
-                tok = AutoTokenizer.from_pretrained(model_name)
-                mdl = AutoModelForSequenceClassification.from_pretrained(model_name).to(self.device)
+                tok = AutoTokenizer.from_pretrained(
+                    model_name,
+                    trust_remote_code=True,
+                )
+                mdl = AutoModelForSequenceClassification.from_pretrained(
+                    model_name,
+                    trust_remote_code=True,
+                ).to(self.device)
             except OSError:
                 base_name = config.NIDS_BASE_MODEL or "distilbert-base-uncased"
                 logger.info(
@@ -85,8 +115,14 @@ class Detector:
                     model_name,
                     base_name,
                 )
-                tok = AutoTokenizer.from_pretrained(base_name)
-                base = AutoModelForSequenceClassification.from_pretrained(base_name)
+                tok = AutoTokenizer.from_pretrained(
+                    base_name,
+                    trust_remote_code=True,
+                )
+                base = AutoModelForSequenceClassification.from_pretrained(
+                    base_name,
+                    trust_remote_code=True,
+                )
                 mdl = PeftModel.from_pretrained(base, model_name).to(self.device)
             self.nids_models.append((model_name, tok, mdl))
         self.semantic_model = SentenceTransformer(config.SEMANTIC_MODEL, device=str(self.device))

--- a/app/preload.py
+++ b/app/preload.py
@@ -17,9 +17,15 @@ def download_models() -> None:
     ]
     for model_name, is_classifier in models:
         try:
-            AutoTokenizer.from_pretrained(model_name)
+            AutoTokenizer.from_pretrained(
+                model_name,
+                trust_remote_code=True,
+            )
             if is_classifier:
-                AutoModelForSequenceClassification.from_pretrained(model_name)
+                AutoModelForSequenceClassification.from_pretrained(
+                    model_name,
+                    trust_remote_code=True,
+                )
         except Exception as exc:
             logger.error("Erro ao baixar %s: %s", model_name, exc)
     try:

--- a/app/sniffer_ai/hf_sniffer.py
+++ b/app/sniffer_ai/hf_sniffer.py
@@ -18,8 +18,14 @@ class HFTextSniffer:
 
     def __init__(self, repo: str = "SilverDragon9/Sniffer.AI") -> None:
         self.repo = repo
-        self.tokenizer = AutoTokenizer.from_pretrained(repo)
-        self.model = AutoModelForSequenceClassification.from_pretrained(repo)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            repo,
+            trust_remote_code=True,
+        )
+        self.model = AutoModelForSequenceClassification.from_pretrained(
+            repo,
+            trust_remote_code=True,
+        )
 
     def predict_from_text(self, text: str):
         inputs = self.tokenizer(text, truncation=True, padding=True, return_tensors="pt")


### PR DESCRIPTION
## Summary
- allow transformers loaders to trust remote code so custom models from `.env` work
- update preload and Sniffer.AI wrappers
- document custom model support

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686c0f1ba464832a88d529c69663dac2