### PR TITLE
Fix model loading for custom NIDS repos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert
 # Comma separated list of NIDS models. The first one is used as primary.
 # Comma separated list of NIDS models. Custom repos com código próprio são
 # suportados com `trust_remote_code` habilitado.
-NIDS_MODELS=Canstralian/CyberAttackDetection
+NIDS_MODELS=gates04/DistilBERT-Network-Intrusion-Detection
 # Legacy variable for compatibility (optional)
 NIDS_MODEL=
 # Base model used when a NIDS entry contains only LoRA adapters

--- a/app/detection.py
+++ b/app/detection.py
@@ -81,7 +81,7 @@ class Detector:
                 self.primary_name,
                 trust_remote_code=True,
             ).to(self.device)
-        except OSError:
+        except (OSError, ValueError):
             base_name = config.NIDS_BASE_MODEL or "distilbert-base-uncased"
             logger.info(
                 "Modelo %s parece ser apenas um adaptador LoRA; carregando base %s",
@@ -108,7 +108,7 @@ class Detector:
                     model_name,
                     trust_remote_code=True,
                 ).to(self.device)
-            except OSError:
+            except (OSError, ValueError):
                 base_name = config.NIDS_BASE_MODEL or "distilbert-base-uncased"
                 logger.info(
                     "Modelo %s parece ser apenas um adaptador LoRA; carregando base %s",


### PR DESCRIPTION
## Summary
- catch `ValueError` when loading NIDS models so repositories without `model_type` still work as LoRA
- use a valid default NIDS model in `.env.example`

## Testing
- `python pentest/test_structure.py`

------
https://chatgpt.com/codex/tasks/task_e_686c14b8b760832aa9eec1a974194351