### PR TITLE
Switch NIDS model and drop attack type field

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,13 +21,12 @@ ANOMALY_MODEL=teoogherghi/Log-Analysis-Model-DistilBert
 # Comma separated list of NIDS models. The first one is used as primary.
 # Comma separated list of NIDS models. Custom repos com código próprio são
 # suportados com `trust_remote_code` habilitado.
-NIDS_MODELS=maleke01/RoBERTa-WebAttack
+# Primary and additional NIDS models separated by comma
+NIDS_MODELS=YangYang-Research/web-attack-detection
 # Legacy variable for compatibility (optional)
 NIDS_MODEL=
 # Base model used when a NIDS entry contains only LoRA adapters
 NIDS_BASE_MODEL=
-# Optional CNN-GRU model for web attack detection
-CNN_GRU_MODEL=
 
 # Similarity threshold for semantic outlier detection
 SEMANTIC_THRESHOLD=0.5

--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
   `trust_remote_code` quando especificados em `.env`.
 - Registro opcional em banco PostgreSQL com esquema definido em `schema.sql`.
 - Integração opcional com OpenSearch para indexar logs e IPs bloqueados.
-- O tipo de ataque é classificado utilizando o(s) modelo(s) definido(s)
-  em `NIDS_MODELS`.
+- A categoria do tráfego é determinada pelo modelo configurado em `NIDS_MODELS`.
 - Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
 - Classificação de ataques realizada apenas por modelos de linguagem, sem regex.
-- A coluna **Principal** exibe o tipo de ataque retornado pelo modelo definido como primário e **Categoria** mostra a maioria dos demais modelos.
 
 ## Instalação
 
@@ -71,7 +69,6 @@ Os limiares usados para bloquear IPs podem ser ajustados por variáveis de ambie
 - `BLOCK_SEVERITY_LEVELS` &ndash; níveis de severidade que resultam em bloqueio imediato (padrão `error,high`).
 - `BLOCK_ANOMALY_THRESHOLD` &ndash; probabilidade mínima de anomalia para bloquear quando o evento também é considerado *outlier* semântico (padrão `0.5`).
 - `NIDS_BASE_MODEL` &ndash; modelo base a ser usado quando um item de `NIDS_MODELS` contém apenas adaptadores LoRA.
-- O tipo de ataque armazenado nos logs utiliza diretamente o rótulo retornado pelo modelo NIDS configurado.
 
 ## Banco de dados
 
@@ -99,8 +96,7 @@ O proxy também monitora a quantidade de requisições de cada IP e bloqueia aut
 ### Modelos para tráfego HTTP
 
 Para detectar ataques em requisições web utilize o(s) modelo(s) configurado(s) em `NIDS_MODELS`.
-Sugerimos o classificador [`maleke01/RoBERTa-WebAttack`](https://huggingface.co/maleke01/RoBERTa-WebAttack) como ponto de partida.
-Também é possível utilizar o modelo híbrido de CNN com GRU disponível em [`YangYang-Research/web-attack-detection`](https://huggingface.co/YangYang-Research/web-attack-detection) definindo `CNN_GRU_MODEL` no `.env`.
+Como referência inicial recomendamos [`YangYang-Research/web-attack-detection`](https://huggingface.co/YangYang-Research/web-attack-detection).
 
 ### Whitelist
 

--- a/app/config.py
+++ b/app/config.py
@@ -30,8 +30,6 @@ NIDS_MODEL = os.getenv('NIDS_MODEL', NIDS_MODELS[0] if NIDS_MODELS else None)
 # Base model to use when a NIDS entry provides only LoRA adapters
 NIDS_BASE_MODEL = os.getenv('NIDS_BASE_MODEL')
 
-# Optional CNN-GRU model for web attack detection
-CNN_GRU_MODEL = os.getenv('CNN_GRU_MODEL')
 
 SEMANTIC_THRESHOLD = float(os.getenv('SEMANTIC_THRESHOLD', '0.5'))
 BLOCK_SEVERITY_LEVELS = [s.strip().lower() for s in os.getenv('BLOCK_SEVERITY_LEVELS', 'error,high').split(',')]

--- a/app/db.py
+++ b/app/db.py
@@ -27,14 +27,14 @@ def init_db():
             cur.execute(f.read())
 
 
-def save_log(interface, data, severity, anomaly, nids, attack_type=None, semantic=None, ip=None, ip_info=None):
+def save_log(interface, data, severity, anomaly, nids, semantic=None, ip=None, ip_info=None):
     if conn is None:
         return None
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute(
             """
-            INSERT INTO logs (iface, log, ip, ip_info, severity, anomaly, nids, attack_type, semantic)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO logs (iface, log, ip, ip_info, severity, anomaly, nids, semantic)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id, created_at
             """,
             (
@@ -45,7 +45,6 @@ def save_log(interface, data, severity, anomaly, nids, attack_type=None, semanti
                 Json(severity),
                 Json(anomaly),
                 Json(nids),
-                attack_type,
                 Json(semantic) if semantic is not None else None,
             ),
         )

--- a/schema.sql
+++ b/schema.sql
@@ -8,7 +8,6 @@ CREATE TABLE IF NOT EXISTS logs (
     severity JSONB,
     anomaly JSONB,
     nids JSONB,
-    attack_type TEXT,
     semantic JSONB
 );
 


### PR DESCRIPTION
## Summary
- drop `attack_type` column and related logic
- remove support for `maleke01/RoBERTa-WebAttack`
- load `YangYang-Research/web-attack-detection` directly as the main NIDS model
- update examples and docs

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686c33397bd0832ab1f520e1ecd7a7b6