### PR TITLE
Add ipinfo CLI integration and IP details pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Instalação de dependências
-RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y git curl ipinfo \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -28,12 +28,17 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
    Caso o arquivo `.env` não exista, a aplicação utilizará valores padrão para
    os modelos, conforme definidos em `app/config.py`.
 2. Instale as dependências do Python:
-   ```bash
-   pip install -r requirements.txt
-   ```
+ ```bash
+  pip install -r requirements.txt
+  ```
    O arquivo já inclui `opensearch-py` na versão 2.x para manter compatibilidade
    com o OpenSearch 2.
-3. (Opcional) Suba o contêiner do Nginx Unit e da aplicação de exemplo:
+3. Instale o cliente da IPinfo para coleta de dados de IPs:
+   ```bash
+   curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.1/ipinfo_3.3.1_linux_$(uname -m).deb
+   sudo dpkg -i ipinfo_3.3.1_linux_$(uname -m).deb
+   ```
+4. (Opcional) Suba o contêiner do Nginx Unit e da aplicação de exemplo:
    ```bash
    docker-compose up -d --build
    ```

--- a/app/ipinfo.py
+++ b/app/ipinfo.py
@@ -1,15 +1,22 @@
 import logging
-import requests
+import json
+import subprocess
 
 logger = logging.getLogger(__name__)
 
 
 def fetch_ip_info(ip: str):
-    """Return IP information from ipinfo.io or None on failure."""
+    """Return IP information using the ipinfo CLI or None on failure."""
     try:
-        resp = requests.get(f"https://ipinfo.io/{ip}/json", timeout=5)
-        if resp.ok:
-            return resp.json()
+        result = subprocess.run(
+            ["ipinfo", ip, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return json.loads(result.stdout)
+        logger.error("ipinfo CLI error for %s: %s", ip, result.stderr.strip())
     except Exception as exc:
         logger.error("Failed to fetch IP info for %s: %s", ip, exc)
     return None

--- a/app/templates/blocked_detail.html
+++ b/app/templates/blocked_detail.html
@@ -8,6 +8,14 @@
     <p><strong>Status:</strong> {{ item.status }}</p>
     <p><strong>Motivo:</strong> {{ item.reason }}</p>
     <p><strong>Data/Hora:</strong> {{ item.blocked_at }}</p>
+    {% if ip_info %}
+    <h5 class="mt-4">Informações do IP</h5>
+    <ul>
+      {% for key, value in ip_info.items() %}
+      <li><strong>{{ key }}:</strong> {{ value }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
     <h5 class="mt-4">Logs Recentes</h5>
     {% if logs %}
     <ul>
@@ -21,6 +29,7 @@
     <form method="post" action="/unblock/{{ item.ip }}" class="mt-3">
       <button type="submit" class="btn btn-danger">Desbloquear IP</button>
     </form>
+    <p class="mt-3"><strong>Modelos Utilizados:</strong> S: {{ models.severity }} | A: {{ models.anomaly }} | N: {{ models.nids }}</p>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/log_detail.html
+++ b/app/templates/log_detail.html
@@ -8,6 +8,16 @@
     <p><strong>Data/Hora:</strong> {{ log.created_at }}</p>
     <p><strong>Origem:</strong> {{ log.iface }}</p>
     <p><strong>IP de Origem:</strong> {{ log.ip }}</p>
+    {% if log.ip_info %}
+    <div class="mt-3">
+      <h5>Informações do IP</h5>
+      <ul>
+        {% for key, value in log.ip_info.items() %}
+        <li><strong>{{ key }}:</strong> {{ value }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
     <p><strong>Ataque Detectado:</strong> {{ 'Sim' if log.is_attack else 'Não' }}</p>
     <p><strong>Intensidade:</strong> {{ intensity }}</p>
     <pre class="mt-3">{{ log.log }}</pre>

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -237,7 +237,22 @@ def blocked_detail(ip: str):
     if not item:
         return 'IP não encontrado', 404
     logs = db.get_logs_by_ip(ip)
-    return render_template('blocked_detail.html', title='IP Bloqueado', item=item, logs=logs)
+    from .ipinfo import fetch_ip_info
+    ip_info = fetch_ip_info(ip)
+    models = {
+        'severity': config.SEVERITY_MODEL,
+        'anomaly': config.ANOMALY_MODEL,
+        'nids': ', '.join(config.NIDS_MODELS),
+        'semantic': config.SEMANTIC_MODEL,
+    }
+    return render_template(
+        'blocked_detail.html',
+        title='IP Bloqueado',
+        item=item,
+        logs=logs,
+        ip_info=ip_info,
+        models=models,
+    )
 
 
 @app.route('/unblock/<ip>', methods=['POST'])


### PR DESCRIPTION
## Summary
- install `ipinfo` CLI in Dockerfile
- use `ipinfo` CLI from `fetch_ip_info`
- display IP information in log and blocked detail pages
- show LLM models on blocked detail page
- document ipinfo installation

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686d2ed66990832a8bee19ba77cc03f5