### PR TITLE
Use ipinfo-cli via Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Instalação de dependências
 RUN apt-get update \
-    && apt-get install -y git curl ipinfo \
+    && apt-get install -y git curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt

--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
   ```
    O arquivo já inclui `opensearch-py` na versão 2.x para manter compatibilidade
    com o OpenSearch 2.
-3. Instale o cliente da IPinfo para coleta de dados de IPs:
-   ```bash
-   curl -LO https://github.com/ipinfo/cli/releases/download/ipinfo-3.3.1/ipinfo_3.3.1_linux_$(uname -m).deb
-   sudo dpkg -i ipinfo_3.3.1_linux_$(uname -m).deb
-   ```
+3. Utilize o **ipinfo-cli** em um contêiner Docker para consultar dados de IPs:
+  ```bash
+  docker run --rm -it ipinfo/ipinfo:3.3.1
+  ```
+  Para salvar a configuração do CLI, monte um volume local:
+  ```bash
+  docker run --rm -it -v "$PWD/ipinfo:/root/.config/ipinfo" ipinfo/ipinfo:3.3.1
+  ```
 4. (Opcional) Suba o contêiner do Nginx Unit e da aplicação de exemplo:
    ```bash
    docker-compose up -d --build

--- a/app/ipinfo.py
+++ b/app/ipinfo.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import os
 import subprocess
 
 logger = logging.getLogger(__name__)
@@ -8,11 +9,16 @@ logger = logging.getLogger(__name__)
 def fetch_ip_info(ip: str):
     """Return IP information using the ipinfo CLI or None on failure."""
     try:
+        cmd = ["docker", "run", "--rm"]
+        config_dir = os.environ.get("IPINFO_CONFIG_DIR")
+        if config_dir:
+            cmd.extend(["-v", f"{config_dir}:/root/.config/ipinfo"])
+        cmd.extend(["ipinfo/ipinfo:3.3.1", ip, "--json"])
         result = subprocess.run(
-            ["ipinfo", ip, "--json"],
+            cmd,
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=10,
         )
         if result.returncode == 0:
             return json.loads(result.stdout)


### PR DESCRIPTION
## Summary
- update Dockerfile to stop installing the ipinfo package
- modify `fetch_ip_info` to run `ipinfo` using the official Docker image
- update README with instructions for using the ipinfo-cli Docker image

## Testing
- `python pentest/test_structure.py`
- `python pentest/test_security.py` *(fails: Connection refused)*
- `python pentest/test_attacks.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686d326aeed0832a8c0b2f1f7e6d62ec