### PR TITLE
Configure ipinfo-cli usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,9 @@ UNIT_BACKEND_PORT=18080
 BACKEND_URL=http://unit:8080
 # Optional path to log file
 LOG_FILE=app.log
+# Token da API do ipinfo.io (opcional)
+IPINFO_TOKEN=
+# Caminho para o banco ipinfo Lite local (opcional)
+IPINFO_MMDB=./mmdb/ipinfo_lite.mmdb
+# Diretório de configuração do ipinfo-cli (opcional)
+IPINFO_CONFIG_DIR=

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ debug.log
 
 # Models
 models/
+mmdb/ipinfo_lite.mmdb

--- a/README.md
+++ b/README.md
@@ -33,13 +33,19 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
   ```
    O arquivo já inclui `opensearch-py` na versão 2.x para manter compatibilidade
    com o OpenSearch 2.
-3. Utilize o **ipinfo-cli** em um contêiner Docker para consultar dados de IPs:
+3. Utilize o **ipinfo-cli** em um contêiner Docker para consultar dados de IPs.
+  Defina o token em `IPINFO_TOKEN` e, opcionalmente, especifique a base
+  `IPINFO_MMDB` quando possuir o arquivo offline `ipinfo_lite.mmdb`:
   ```bash
   docker run --rm -it ipinfo/ipinfo:3.3.1
   ```
   Para salvar a configuração do CLI, monte um volume local:
   ```bash
   docker run --rm -it -v "$PWD/ipinfo:/root/.config/ipinfo" ipinfo/ipinfo:3.3.1
+  ```
+  Exemplo direto de consulta via API:
+  ```bash
+  curl "https://api.ipinfo.io/lite/8.8.8.8?token=71c4a89dd05d28"
   ```
 4. (Opcional) Suba o contêiner do Nginx Unit e da aplicação de exemplo:
    ```bash

--- a/app/config.py
+++ b/app/config.py
@@ -40,6 +40,10 @@ WEB_PANEL_PORT = int(os.getenv('WEB_PANEL_PORT', '8080'))
 UNIT_PORT = int(os.getenv('UNIT_PORT', '8090'))
 BACKEND_URL = os.getenv('BACKEND_URL', 'http://hello:8000')
 LOG_FILE = os.getenv('LOG_FILE', 'app.log')
+# Ipinfo configuration
+IPINFO_TOKEN = os.getenv('IPINFO_TOKEN')
+IPINFO_MMDB = os.getenv('IPINFO_MMDB', os.path.join(os.path.dirname(os.path.dirname(__file__)), 'mmdb', 'ipinfo_lite.mmdb'))
+IPINFO_CONFIG_DIR = os.getenv('IPINFO_CONFIG_DIR')
 
 # If ``LOG_FILE`` is a relative path, place it inside the application
 # directory so the Unit process has permission to write the file. When the

--- a/app/ipinfo.py
+++ b/app/ipinfo.py
@@ -13,14 +13,29 @@ def fetch_ip_info(ip: str):
         config_dir = os.environ.get("IPINFO_CONFIG_DIR")
         if config_dir:
             cmd.extend(["-v", f"{config_dir}:/root/.config/ipinfo"])
-        cmd.extend(["ipinfo/ipinfo:3.3.1", ip, "--json"])
+
+        token = os.environ.get("IPINFO_TOKEN")
+        mmdb_path = os.environ.get(
+            "IPINFO_MMDB",
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), "mmdb", "ipinfo_lite.mmdb"),
+        )
+
+        if os.path.exists(mmdb_path):
+            cmd.extend(["-v", f"{mmdb_path}:/db.mmdb"])
+            cmd.extend(["ipinfo/ipinfo:3.3.1", "mmdb", "read", ip, "/db.mmdb", "--format", "json"])
+        else:
+            cmd.append("ipinfo/ipinfo:3.3.1")
+            if token:
+                cmd.extend(["-t", token])
+            cmd.extend([ip, "--json"])
+
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             timeout=10,
         )
-        if result.returncode == 0:
+        if result.returncode == 0 and result.stdout.strip():
             return json.loads(result.stdout)
         logger.error("ipinfo CLI error for %s: %s", ip, result.stderr.strip())
     except Exception as exc:

--- a/mmdb/README.md
+++ b/mmdb/README.md
@@ -1,0 +1,3 @@
+# IPinfo Lite Database
+
+Coloque aqui o arquivo `ipinfo_lite.mmdb` obtido com o ipinfo-cli ou download manual.


### PR DESCRIPTION
## Summary
- configure ipinfo options in `.env.example` and app config
- extend ipinfo helper to support API token and offline MMDB file
- document how to use ipinfo-cli in README
- ignore downloaded database and add placeholder directory

## Testing
- `python pentest/test_structure.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686d3ad52944832abddd633ccd50c16f