### PR TITLE
Improve pentest coverage

### DIFF
--- a/pentest/test_attacks.py
+++ b/pentest/test_attacks.py
@@ -16,3 +16,12 @@ def test_multiple_attacks(client):
 
     logs = client.get("/api/logs").get_json()
     assert len(logs) == len(ATTACKS)
+    seen = {payload: False for payload in ATTACKS.values()}
+    for entry in logs:
+        log_text = entry.get("log", "")
+        for payload in ATTACKS.values():
+            if payload in log_text:
+                seen[payload] = True
+        for key in ("severity", "anomaly", "nids", "intensity"):
+            assert key in entry
+    assert all(seen.values())

--- a/pentest/test_events.py
+++ b/pentest/test_events.py
@@ -1,0 +1,20 @@
+import queue
+from app import events
+
+
+def test_event_notifications():
+    log_q = events.register_log_listener()
+    blocked_q = events.register_blocked_listener()
+
+    log_entry = {"id": 1, "log": "test"}
+    events.notify_log(log_entry)
+    received_log = log_q.get(timeout=1)
+    assert received_log == log_entry
+
+    block_entry = {"ip": "1.2.3.4", "reason": "test"}
+    events.notify_blocked(block_entry)
+    received_block = blocked_q.get(timeout=1)
+    assert received_block == block_entry
+
+    events.unregister_log_listener(log_q)
+    events.unregister_blocked_listener(blocked_q)

--- a/pentest/test_firewall.py
+++ b/pentest/test_firewall.py
@@ -1,0 +1,66 @@
+import sys
+import types
+import subprocess
+
+
+def _import_firewall():
+    # Prepare dummy dependencies so firewall can be imported
+    import importlib
+    sys.modules.setdefault("psycopg2", types.ModuleType("psycopg2"))
+    extras_mod = types.ModuleType("psycopg2.extras")
+    setattr(extras_mod, "RealDictCursor", object)
+    setattr(extras_mod, "Json", object)
+    sys.modules.setdefault("psycopg2.extras", extras_mod)
+    dotenv_mod = types.ModuleType("dotenv")
+    setattr(dotenv_mod, "load_dotenv", lambda *a, **k: None)
+    sys.modules.setdefault("dotenv", dotenv_mod)
+    if "app.firewall" in sys.modules:
+        del sys.modules["app.firewall"]
+    return importlib.import_module("app.firewall")
+
+
+def test_block_and_unblock_ip(monkeypatch):
+    firewall = _import_firewall()
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        class Result:
+            stdout = ""
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(firewall, "is_whitelisted", lambda ip: False)
+    monkeypatch.setattr(firewall, "is_ip_blocked", lambda ip: False)
+    monkeypatch.setattr(firewall.config, "UNIT_BACKEND_PORT", 9999)
+
+    assert firewall.block_ip("1.2.3.4") is True
+    assert calls[0] == [
+        "sudo",
+        "ufw",
+        "insert",
+        "1",
+        "deny",
+        "from",
+        "1.2.3.4",
+        "to",
+        "any",
+        "port",
+        "9999",
+    ]
+
+    calls.clear()
+    monkeypatch.setattr(firewall, "is_ip_blocked", lambda ip: True)
+    assert firewall.unblock_ip("1.2.3.4") is True
+    assert calls[0] == [
+        "sudo",
+        "ufw",
+        "delete",
+        "deny",
+        "from",
+        "1.2.3.4",
+        "to",
+        "any",
+        "port",
+        "9999",
+    ]

--- a/pentest/test_intensity.py
+++ b/pentest/test_intensity.py
@@ -1,0 +1,25 @@
+import ast
+from pathlib import Path
+
+# Extract the calculate_intensity function source without importing heavy deps
+src = Path(__file__).resolve().parents[1] / "app" / "detection.py"
+mod_ast = ast.parse(src.read_text())
+func_src = None
+for node in mod_ast.body:
+    if isinstance(node, ast.FunctionDef) and node.name == "calculate_intensity":
+        func_src = ast.get_source_segment(src.read_text(), node)
+        break
+
+namespace = {}
+exec(func_src, namespace)
+calculate_intensity = namespace["calculate_intensity"]
+
+
+def test_calculate_intensity_high():
+    intensity = calculate_intensity("high", [0.2, 0.8], 0.1)
+    assert intensity == 216.0
+
+
+def test_calculate_intensity_low():
+    intensity = calculate_intensity("low", [0.5], 0.2)
+    assert intensity == 40.0


### PR DESCRIPTION
## Summary
- verify severity metadata in multi-attack test
- add direct unit tests for calculate_intensity
- ensure events notification queue works
- add mocked firewall interaction tests

## Testing
- `pytest pentest/test_structure.py pentest/test_security.py pentest/test_attacks.py pentest/test_intensity.py pentest/test_events.py pentest/test_firewall.py`

------
https://chatgpt.com/codex/tasks/task_e_686d7c799e90832a9dd9c723ba084f9a