### PR TITLE
Rename security tabs

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -69,8 +69,8 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav mx-auto mb-2 mb-lg-0">
-                    <li class="nav-item"><a class="nav-link fw-bold text-white" style="font-size:1.1rem" href="/logs">Registros</a></li>
-                    <li class="nav-item"><a class="nav-link fw-bold text-white" style="font-size:1.1rem" href="/blocked">Jaula</a></li>
+                    <li class="nav-item"><a class="nav-link fw-bold text-white" style="font-size:1.1rem" href="/logs">Logs de Ameaças</a></li>
+                    <li class="nav-item"><a class="nav-link fw-bold text-white" style="font-size:1.1rem" href="/blocked">Quarentena de IPs</a></li>
                 </ul>
                 <span id="model-info" class="navbar-text me-3 text-white small"></span>
                 <button id="toggle-btn" class="btn btn-outline-light">Alternar tema</button>

--- a/app/templates/blocked.html
+++ b/app/templates/blocked.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div id="blocked-app">
-  <h1 class="display-5 mb-4 text-center">Jaula de IPs Bloqueados</h1>
+  <h1 class="display-5 mb-4 text-center">Quarentena de IPs</h1>
   <div class="card">
     <div class="card-body p-0">
       <div class="table-responsive">

--- a/app/templates/blocked_detail.html
+++ b/app/templates/blocked_detail.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1 class="display-5 mb-4 text-center">Detalhes do IP</h1>
+<h1 class="display-5 mb-4 text-center">Detalhes do IP Quarentenado</h1>
 <div class="card">
   <div class="card-body">
     <p><strong>IP:</strong> {{ item.ip }}</p>

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div id="logs-app">
-  <h1 class="display-5 mb-4 text-center">Registros de Requisições</h1>
+  <h1 class="display-5 mb-4 text-center">Logs de Ameaças</h1>
   <div class="card">
     <div class="card-body p-0">
       <div class="table-responsive">

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -203,7 +203,7 @@ def logs():
         'nids': ', '.join(config.NIDS_MODELS),
         'semantic': config.SEMANTIC_MODEL,
     }
-    return render_template('logs.html', title='Logs', logs=logs, page=page, models=models)
+    return render_template('logs.html', title='Logs de Ameaças', logs=logs, page=page, models=models)
 
 
 @app.route('/log/<int:log_id>')
@@ -237,7 +237,7 @@ def blocked():
         'nids': ', '.join(config.NIDS_MODELS),
         'semantic': config.SEMANTIC_MODEL,
     }
-    return render_template('blocked.html', title='IPs Bloqueados', blocked=blocked, page=page, models=models)
+    return render_template('blocked.html', title='Quarentena de IPs', blocked=blocked, page=page, models=models)
 
 
 @app.route('/blocked/<ip>')
@@ -258,7 +258,7 @@ def blocked_detail(ip: str):
     }
     return render_template(
         'blocked_detail.html',
-        title='IP Bloqueado',
+        title='IP Quarentenado',
         item=item,
         logs=logs,
         ip_info=ip_info,


### PR DESCRIPTION
## Summary
- update navbar links using common security jargon
- retitle logs page as "Logs de Ameaças"
- retitle blocked page and details as "Quarentena de IPs"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d82ec7c10832a894457498a82e17c