### PR TITLE
Implement separate logs views

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -70,6 +70,7 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav mx-auto mb-2 mb-lg-0">
                     <li class="nav-item"><a class="nav-link fw-bold text-white" style="font-size:1.1rem" href="/logs">Logs de Ameaças</a></li>
+                    <li class="nav-item"><a class="nav-link fw-bold text-white" style="font-size:1.1rem" href="/common-logs">Logs Comuns</a></li>
                     <li class="nav-item"><a class="nav-link fw-bold text-white" style="font-size:1.1rem" href="/blocked">Quarentena de IPs</a></li>
                 </ul>
                 <span id="model-info" class="navbar-text me-3 text-white small"></span>


### PR DESCRIPTION
## Summary
- filter non-attack logs in `/logs`
- add `/common-logs` route for attack logs
- update navigation to link to new page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d84f3a54c832aa2a92d9cfd292d12