### PR TITLE
Fix threat log routing

### DIFF
--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -198,7 +198,7 @@ def logs():
             item['anomaly']['score'],
             item.get('semantic', {}).get('similarity', 1.0),
         )
-        if not item['is_attack']:
+        if item['is_attack']:
             filtered.append(item)
     models = {
         'severity': config.SEVERITY_MODEL,
@@ -222,7 +222,7 @@ def common_logs():
             item['anomaly']['score'],
             item.get('semantic', {}).get('similarity', 1.0),
         )
-        if item['is_attack']:
+        if not item['is_attack']:
             filtered.append(item)
     models = {
         'severity': config.SEVERITY_MODEL,


### PR DESCRIPTION
## Summary
- route attack logs to threat tab
- route normal logs to common log tab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d87297594832a9df2da8944cead7a