### PR TITLE
Separate threat and common logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Defina `POSTGRES_HOST` e as demais variáveis de conexão para ativar o uso de P
 
 Além disso, é possível enviar os registros para um cluster OpenSearch (versão comunidade). Configure `ES_HOST` com a URL do servidor e, opcionalmente, `ES_USER`/`ES_PASSWORD` caso a autenticação esteja habilitada. Os documentos são indexados nos índices `logs` e `blocked_ips` para facilitar buscas e visualizações via Kibana ou ferramentas compatíveis.
 
+Os registros são gravados em tabelas distintas conforme a classificação realizada pelos modelos de linguagem. Requisições identificadas como ataque ficam em `threat_logs`, enquanto as demais são armazenadas em `common_logs`.
+
 ## Pentest e testes
 
 A pasta `pentest` inclui scripts de verificação e testes de ataque:

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1,4 +1,11 @@
-from flask import Flask, render_template, jsonify, request, Response, stream_with_context
+from flask import (
+    Flask,
+    render_template,
+    jsonify,
+    request,
+    Response,
+    stream_with_context,
+)
 import requests
 import json
 import time
@@ -27,6 +34,7 @@ def _sync_initial_blocked() -> None:
     """Ensure database reflects current UFW state on startup."""
     firewall.sync_blocked_ips_with_ufw()
 
+
 # ``before_first_request`` was removed in Flask 3.x. Call the function once
 # during startup instead of registering it as a hook.
 _sync_initial_blocked()
@@ -45,15 +53,15 @@ def _is_attack(label: str) -> bool:
 @app.before_request
 def _analyze():
     if (
-        request.path.startswith('/logs')
-        or request.path.startswith('/blocked')
-        or request.path.startswith('/api/')
-        or request.path.startswith('/stream/')
+        request.path.startswith("/logs")
+        or request.path.startswith("/blocked")
+        or request.path.startswith("/api/")
+        or request.path.startswith("/stream/")
     ):
         return
     result = analyze_request()
-    if isinstance(result, dict) and result.get('blocked'):
-        return Response('Bloqueado', status=403)
+    if isinstance(result, dict) and result.get("blocked"):
+        return Response("Bloqueado", status=403)
 
 
 def analyze_request() -> dict:
@@ -65,26 +73,27 @@ def analyze_request() -> dict:
     ip_info = None
     if ip:
         from .ipinfo import fetch_ip_info
+
         ip_info = fetch_ip_info(ip)
     result = detector.analyze(full_text)
-    category = result['nids'].get('majority', result['nids']['label'])
+    category = result["nids"].get("majority", result["nids"]["label"])
     logger.info(
         "Detection result - severity: %s, anomaly: %s, nids: %s",
-        result['severity']['label'],
-        result['anomaly']['label'],
-        result['nids']['label'],
+        result["severity"]["label"],
+        result["anomaly"]["label"],
+        result["nids"]["label"],
     )
     saved = db.save_log(
-        'unit',
+        "unit",
         full_text,
-        result['severity'],
-        result['anomaly'],
-        result['nids'],
-        result['semantic'],
+        result["severity"],
+        result["anomaly"],
+        result["nids"],
+        result["semantic"],
         ip=ip,
         ip_info=ip_info,
     )
-    created_at = time.strftime('%Y-%m-%d %H:%M:%S')
+    created_at = time.strftime("%Y-%m-%d %H:%M:%S")
     log_id = None
     if saved:
         log_id, created_at_dt = saved
@@ -92,40 +101,44 @@ def analyze_request() -> dict:
             created_at = created_at_dt.strftime("%Y-%m-%d %H:%M:%S")
         else:
             created_at = str(created_at_dt)
-    events.notify_log({
-        'id': log_id,
-        'created_at': created_at,
-        'iface': 'unit',
-        'log': full_text,
-        'ip': ip,
-        'ip_info': ip_info,
-        'severity': result['severity'],
-        'anomaly': result['anomaly'],
-        'nids': result['nids'],
-        'category': category,
-        'is_attack': _is_attack(category),
-        'semantic': result['semantic'],
-        'intensity': result['intensity'],
-    })
-    es.index_log({
-        'id': log_id,
-        'created_at': created_at,
-        'iface': 'unit',
-        'log': full_text,
-        'ip': ip,
-        'ip_info': ip_info,
-        'severity': result['severity'],
-        'anomaly': result['anomaly'],
-        'nids': result['nids'],
-        'category': category,
-        'is_attack': _is_attack(category),
-        'semantic': result['semantic'],
-        'intensity': result['intensity'],
-    })
-    sev = str(result['severity']['label']).lower()
-    anom = str(result['anomaly']['label']).lower()
-    anom_score = max(result['anomaly']['score']) if result['anomaly']['score'] else 0.0
-    sem_outlier = bool(result.get('semantic', {}).get('outlier'))
+    events.notify_log(
+        {
+            "id": log_id,
+            "created_at": created_at,
+            "iface": "unit",
+            "log": full_text,
+            "ip": ip,
+            "ip_info": ip_info,
+            "severity": result["severity"],
+            "anomaly": result["anomaly"],
+            "nids": result["nids"],
+            "category": category,
+            "is_attack": _is_attack(category),
+            "semantic": result["semantic"],
+            "intensity": result["intensity"],
+        }
+    )
+    es.index_log(
+        {
+            "id": log_id,
+            "created_at": created_at,
+            "iface": "unit",
+            "log": full_text,
+            "ip": ip,
+            "ip_info": ip_info,
+            "severity": result["severity"],
+            "anomaly": result["anomaly"],
+            "nids": result["nids"],
+            "category": category,
+            "is_attack": _is_attack(category),
+            "semantic": result["semantic"],
+            "intensity": result["intensity"],
+        }
+    )
+    sev = str(result["severity"]["label"]).lower()
+    anom = str(result["anomaly"]["label"]).lower()
+    anom_score = max(result["anomaly"]["score"]) if result["anomaly"]["score"] else 0.0
+    sem_outlier = bool(result.get("semantic", {}).get("outlier"))
     if ip:
         now = time.time()
         dq = REQUEST_COUNTS[ip]
@@ -135,26 +148,30 @@ def analyze_request() -> dict:
         if len(dq) > DOS_THRESHOLD:
             if firewall.block_ip(ip):
                 logger.warning("IP %s blocked due to DoS detection", ip)
-                db.save_blocked_ip(ip, 'dos', ip_info=ip_info)
-                events.notify_blocked({
-                    'ip': ip,
-                    'reason': 'dos',
-                    'status': 'blocked',
-                    'blocked_at': time.strftime('%Y-%m-%d %H:%M:%S')
-                    ,'ip_info': ip_info,
-                })
-                es.index_blocked_ip({
-                    'ip': ip,
-                    'reason': 'dos',
-                    'status': 'blocked',
-                    'blocked_at': time.strftime('%Y-%m-%d %H:%M:%S'),
-                    'ip_info': ip_info,
-                })
-                return {'blocked': True}
+                db.save_blocked_ip(ip, "dos", ip_info=ip_info)
+                events.notify_blocked(
+                    {
+                        "ip": ip,
+                        "reason": "dos",
+                        "status": "blocked",
+                        "blocked_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+                        "ip_info": ip_info,
+                    }
+                )
+                es.index_blocked_ip(
+                    {
+                        "ip": ip,
+                        "reason": "dos",
+                        "status": "blocked",
+                        "blocked_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+                        "ip_info": ip_info,
+                    }
+                )
+                return {"blocked": True}
 
         block_by_sev = sev in config.BLOCK_SEVERITY_LEVELS
         block_by_anom = (
-            anom not in ('normal', 'none')
+            anom not in ("normal", "none")
             and sem_outlier
             and anom_score >= config.BLOCK_ANOMALY_THRESHOLD
         )
@@ -163,129 +180,145 @@ def analyze_request() -> dict:
                 reason = f"{result['anomaly']['label']} / {result['severity']['label']}"
                 logger.warning("IP %s blocked: %s", ip, reason)
                 db.save_blocked_ip(ip, reason, ip_info=ip_info)
-                events.notify_blocked({
-                    'ip': ip,
-                    'reason': reason,
-                    'status': 'blocked',
-                    'blocked_at': time.strftime('%Y-%m-%d %H:%M:%S'),
-                    'ip_info': ip_info,
-                })
-                es.index_blocked_ip({
-                    'ip': ip,
-                    'reason': reason,
-                    'status': 'blocked',
-                    'blocked_at': time.strftime('%Y-%m-%d %H:%M:%S'),
-                    'ip_info': ip_info,
-                })
-                return {'blocked': True}
+                events.notify_blocked(
+                    {
+                        "ip": ip,
+                        "reason": reason,
+                        "status": "blocked",
+                        "blocked_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+                        "ip_info": ip_info,
+                    }
+                )
+                es.index_blocked_ip(
+                    {
+                        "ip": ip,
+                        "reason": reason,
+                        "status": "blocked",
+                        "blocked_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+                        "ip_info": ip_info,
+                    }
+                )
+                return {"blocked": True}
     return result
 
 
-@app.route('/')
+@app.route("/")
 def index():
-    return 'Nginx Unit running'
+    return "Nginx Unit running"
 
-@app.route('/logs')
+
+@app.route("/logs")
 def logs():
-    page = int(request.args.get('page', '1'))
-    logs = db.get_logs(limit=100, offset=(page - 1) * 100)
-    filtered = []
+    page = int(request.args.get("page", "1"))
+    logs = db.get_threat_logs(limit=100, offset=(page - 1) * 100)
     for item in logs:
-        item['category'] = item['nids'].get('majority', item['nids']['label'])
-        item['is_attack'] = _is_attack(item['category'])
-        item['intensity'] = detection.calculate_intensity(
-            item['severity']['label'],
-            item['anomaly']['score'],
-            item.get('semantic', {}).get('similarity', 1.0),
+        item["category"] = item["nids"].get("majority", item["nids"]["label"])
+        item["is_attack"] = True
+        item["intensity"] = detection.calculate_intensity(
+            item["severity"]["label"],
+            item["anomaly"]["score"],
+            item.get("semantic", {}).get("similarity", 1.0),
         )
-        if item['is_attack']:
-            filtered.append(item)
+    filtered = logs
     models = {
-        'severity': config.SEVERITY_MODEL,
-        'anomaly': config.ANOMALY_MODEL,
-        'nids': ', '.join(config.NIDS_MODELS),
-        'semantic': config.SEMANTIC_MODEL,
+        "severity": config.SEVERITY_MODEL,
+        "anomaly": config.ANOMALY_MODEL,
+        "nids": ", ".join(config.NIDS_MODELS),
+        "semantic": config.SEMANTIC_MODEL,
     }
-    return render_template('logs.html', title='Logs de Ameaças', logs=filtered, page=page, models=models)
+    return render_template(
+        "logs.html", title="Logs de Ameaças", logs=filtered, page=page, models=models
+    )
 
 
-@app.route('/common-logs')
+@app.route("/common-logs")
 def common_logs():
-    page = int(request.args.get('page', '1'))
-    logs = db.get_logs(limit=100, offset=(page - 1) * 100)
-    filtered = []
+    page = int(request.args.get("page", "1"))
+    logs = db.get_common_logs(limit=100, offset=(page - 1) * 100)
     for item in logs:
-        item['category'] = item['nids'].get('majority', item['nids']['label'])
-        item['is_attack'] = _is_attack(item['category'])
-        item['intensity'] = detection.calculate_intensity(
-            item['severity']['label'],
-            item['anomaly']['score'],
-            item.get('semantic', {}).get('similarity', 1.0),
+        item["category"] = item["nids"].get("majority", item["nids"]["label"])
+        item["is_attack"] = False
+        item["intensity"] = detection.calculate_intensity(
+            item["severity"]["label"],
+            item["anomaly"]["score"],
+            item.get("semantic", {}).get("similarity", 1.0),
         )
-        if not item['is_attack']:
-            filtered.append(item)
+    filtered = logs
     models = {
-        'severity': config.SEVERITY_MODEL,
-        'anomaly': config.ANOMALY_MODEL,
-        'nids': ', '.join(config.NIDS_MODELS),
-        'semantic': config.SEMANTIC_MODEL,
+        "severity": config.SEVERITY_MODEL,
+        "anomaly": config.ANOMALY_MODEL,
+        "nids": ", ".join(config.NIDS_MODELS),
+        "semantic": config.SEMANTIC_MODEL,
     }
-    return render_template('logs.html', title='Logs Comuns', logs=filtered, page=page, models=models)
+    return render_template(
+        "logs.html", title="Logs Comuns", logs=filtered, page=page, models=models
+    )
 
 
-@app.route('/log/<int:log_id>')
+@app.route("/log/<int:log_id>")
 def log_detail(log_id: int):
     log = db.get_log(log_id)
     if not log:
-        return 'Log não encontrado', 404
-    log['category'] = log['nids'].get('majority', log['nids']['label'])
-    log['is_attack'] = _is_attack(log['category'])
+        return "Log não encontrado", 404
+    log["category"] = log["nids"].get("majority", log["nids"]["label"])
+    if "is_attack" not in log:
+        log["is_attack"] = _is_attack(log["category"])
     intensity = detection.calculate_intensity(
-        log['severity']['label'],
-        log['anomaly']['score'],
-        log.get('semantic', {}).get('similarity', 1.0),
+        log["severity"]["label"],
+        log["anomaly"]["score"],
+        log.get("semantic", {}).get("similarity", 1.0),
     )
-    if log.get('ip') and not log.get('ip_info'):
+    if log.get("ip") and not log.get("ip_info"):
         from .ipinfo import fetch_ip_info
-        ip_info = fetch_ip_info(log['ip'])
+
+        ip_info = fetch_ip_info(log["ip"])
         if ip_info:
-            log['ip_info'] = ip_info
-    return render_template('log_detail.html', title='Detalhes do Log', log=log, intensity=intensity)
+            log["ip_info"] = ip_info
+    return render_template(
+        "log_detail.html", title="Detalhes do Log", log=log, intensity=intensity
+    )
 
 
-@app.route('/blocked')
+@app.route("/blocked")
 def blocked():
-    page = int(request.args.get('page', '1'))
+    page = int(request.args.get("page", "1"))
     firewall.sync_blocked_ips_with_ufw()
     blocked = db.get_blocked_ips(limit=100, offset=(page - 1) * 100)
     models = {
-        'severity': config.SEVERITY_MODEL,
-        'anomaly': config.ANOMALY_MODEL,
-        'nids': ', '.join(config.NIDS_MODELS),
-        'semantic': config.SEMANTIC_MODEL,
+        "severity": config.SEVERITY_MODEL,
+        "anomaly": config.ANOMALY_MODEL,
+        "nids": ", ".join(config.NIDS_MODELS),
+        "semantic": config.SEMANTIC_MODEL,
     }
-    return render_template('blocked.html', title='Quarentena de IPs', blocked=blocked, page=page, models=models)
+    return render_template(
+        "blocked.html",
+        title="Quarentena de IPs",
+        blocked=blocked,
+        page=page,
+        models=models,
+    )
 
 
-@app.route('/blocked/<ip>')
+@app.route("/blocked/<ip>")
 def blocked_detail(ip: str):
     item = db.get_blocked_ip(ip)
     if not item:
-        return 'IP não encontrado', 404
+        return "IP não encontrado", 404
     logs = db.get_logs_by_ip(ip)
-    ip_info = item.get('ip_info')
+    ip_info = item.get("ip_info")
     if not ip_info:
         from .ipinfo import fetch_ip_info
+
         ip_info = fetch_ip_info(ip)
     models = {
-        'severity': config.SEVERITY_MODEL,
-        'anomaly': config.ANOMALY_MODEL,
-        'nids': ', '.join(config.NIDS_MODELS),
-        'semantic': config.SEMANTIC_MODEL,
+        "severity": config.SEVERITY_MODEL,
+        "anomaly": config.ANOMALY_MODEL,
+        "nids": ", ".join(config.NIDS_MODELS),
+        "semantic": config.SEMANTIC_MODEL,
     }
     return render_template(
-        'blocked_detail.html',
-        title='IP Quarentenado',
+        "blocked_detail.html",
+        title="IP Quarentenado",
         item=item,
         logs=logs,
         ip_info=ip_info,
@@ -293,73 +326,86 @@ def blocked_detail(ip: str):
     )
 
 
-@app.route('/unblock/<ip>', methods=['POST'])
+@app.route("/unblock/<ip>", methods=["POST"])
 def unblock_ip_route(ip: str):
     if firewall.unblock_ip(ip):
         db.unblock_ip(ip)
-        events.notify_blocked({
-            'ip': ip,
-            'reason': 'manual',
-            'status': 'unblocked',
-            'blocked_at': time.strftime('%Y-%m-%d %H:%M:%S')
-        })
-        es.index_blocked_ip({
-            'ip': ip,
-            'reason': 'manual',
-            'status': 'unblocked',
-            'blocked_at': time.strftime('%Y-%m-%d %H:%M:%S')
-        })
-    return ('', 204)
+        events.notify_blocked(
+            {
+                "ip": ip,
+                "reason": "manual",
+                "status": "unblocked",
+                "blocked_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        )
+        es.index_blocked_ip(
+            {
+                "ip": ip,
+                "reason": "manual",
+                "status": "unblocked",
+                "blocked_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        )
+    return ("", 204)
 
 
-@app.route('/api/unblock/<ip>', methods=['POST'])
+@app.route("/api/unblock/<ip>", methods=["POST"])
 def api_unblock(ip: str):
     if firewall.unblock_ip(ip):
         db.unblock_ip(ip)
-        events.notify_blocked({
-            'ip': ip,
-            'reason': 'manual',
-            'status': 'unblocked',
-            'blocked_at': time.strftime('%Y-%m-%d %H:%M:%S')
-        })
-        es.index_blocked_ip({
-            'ip': ip,
-            'reason': 'manual',
-            'status': 'unblocked',
-            'blocked_at': time.strftime('%Y-%m-%d %H:%M:%S')
-        })
-    return ('', 204)
+        events.notify_blocked(
+            {
+                "ip": ip,
+                "reason": "manual",
+                "status": "unblocked",
+                "blocked_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        )
+        es.index_blocked_ip(
+            {
+                "ip": ip,
+                "reason": "manual",
+                "status": "unblocked",
+                "blocked_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        )
+    return ("", 204)
 
-@app.route('/api/logs')
+
+@app.route("/api/logs")
 def api_logs():
-    page = int(request.args.get('page', '1'))
+    page = int(request.args.get("page", "1"))
     logs = db.get_logs(limit=100, offset=(page - 1) * 100)
     serialized = []
     for log in logs:
         intensity = detection.calculate_intensity(
-            log['severity']['label'],
-            log['anomaly']['score'],
-            log.get('semantic', {}).get('similarity', 1.0),
+            log["severity"]["label"],
+            log["anomaly"]["score"],
+            log.get("semantic", {}).get("similarity", 1.0),
         )
-        serialized.append({
-            'id': log.get('id'),
-            'created_at': str(log['created_at']),
-            'iface': log['iface'],
-            'log': log['log'],
-            'ip': log.get('ip'),
-            'ip_info': log.get('ip_info'),
-            'severity': log['severity'],
-            'anomaly': log['anomaly'],
-            'nids': log['nids'],
-            'category': log['nids'].get('majority', log['nids']['label']),
-            'is_attack': _is_attack(log['nids'].get('majority', log['nids']['label'])),
-            'semantic': log.get('semantic'),
-            'intensity': intensity,
-        })
+        serialized.append(
+            {
+                "id": log.get("id"),
+                "created_at": str(log["created_at"]),
+                "iface": log["iface"],
+                "log": log["log"],
+                "ip": log.get("ip"),
+                "ip_info": log.get("ip_info"),
+                "severity": log["severity"],
+                "anomaly": log["anomaly"],
+                "nids": log["nids"],
+                "category": log["nids"].get("majority", log["nids"]["label"]),
+                "is_attack": _is_attack(
+                    log["nids"].get("majority", log["nids"]["label"])
+                ),
+                "semantic": log.get("semantic"),
+                "intensity": intensity,
+            }
+        )
     return jsonify(serialized)
 
 
-@app.route('/stream/logs')
+@app.route("/stream/logs")
 def stream_logs():
     def generator():
         q = events.register_log_listener()
@@ -370,10 +416,10 @@ def stream_logs():
         finally:
             events.unregister_log_listener(q)
 
-    return Response(stream_with_context(generator()), mimetype='text/event-stream')
+    return Response(stream_with_context(generator()), mimetype="text/event-stream")
 
 
-@app.route('/stream/blocked')
+@app.route("/stream/blocked")
 def stream_blocked():
     def generator():
         q = events.register_blocked_listener()
@@ -384,21 +430,21 @@ def stream_blocked():
         finally:
             events.unregister_blocked_listener(q)
 
-    return Response(stream_with_context(generator()), mimetype='text/event-stream')
+    return Response(stream_with_context(generator()), mimetype="text/event-stream")
 
 
-@app.route('/api/blocked')
+@app.route("/api/blocked")
 def api_blocked():
-    page = int(request.args.get('page', '1'))
+    page = int(request.args.get("page", "1"))
     firewall.sync_blocked_ips_with_ufw()
     blocked = db.get_blocked_ips(limit=100, offset=(page - 1) * 100)
     serialized = [
         {
-            'ip': item['ip'],
-            'reason': item['reason'],
-            'status': item['status'],
-            'blocked_at': str(item['blocked_at']),
-            'ip_info': item.get('ip_info'),
+            "ip": item["ip"],
+            "reason": item["reason"],
+            "status": item["status"],
+            "blocked_at": str(item["blocked_at"]),
+            "ip_info": item.get("ip_info"),
         }
         for item in blocked
     ]
@@ -411,7 +457,7 @@ def _forward(path: str):
         resp = requests.request(
             method=request.method,
             url=url,
-            headers={k: v for k, v in request.headers if k.lower() != 'host'},
+            headers={k: v for k, v in request.headers if k.lower() != "host"},
             params=request.args,
             data=request.get_data(),
             allow_redirects=False,
@@ -419,14 +465,19 @@ def _forward(path: str):
         )
     except Exception as exc:
         return Response(f"Erro ao encaminhar: {exc}", status=502)
-    excluded = {'content-encoding', 'content-length', 'transfer-encoding', 'connection'}
+    excluded = {"content-encoding", "content-length", "transfer-encoding", "connection"}
     headers = [(k, v) for k, v in resp.headers.items() if k.lower() not in excluded]
     return Response(resp.content, resp.status_code, headers)
 
 
-@app.route('/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'])
-@app.route('/', defaults={'path': ''}, methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'])
+@app.route("/<path:path>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
+@app.route(
+    "/",
+    defaults={"path": ""},
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+)
 def catch_all(path: str):
     return _forward(path)
+
 
 application = app

--- a/schema.sql
+++ b/schema.sql
@@ -11,6 +11,33 @@ CREATE TABLE IF NOT EXISTS logs (
     semantic JSONB
 );
 
+-- Tabelas separadas para registros de ameacas e logs comuns
+CREATE TABLE IF NOT EXISTS threat_logs (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    iface TEXT NOT NULL,
+    log TEXT NOT NULL,
+    ip TEXT,
+    ip_info JSONB,
+    severity JSONB,
+    anomaly JSONB,
+    nids JSONB,
+    semantic JSONB
+);
+
+CREATE TABLE IF NOT EXISTS common_logs (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    iface TEXT NOT NULL,
+    log TEXT NOT NULL,
+    ip TEXT,
+    ip_info JSONB,
+    severity JSONB,
+    anomaly JSONB,
+    nids JSONB,
+    semantic JSONB
+);
+
 CREATE TABLE IF NOT EXISTS blocked_ips (
     id SERIAL PRIMARY KEY,
     ip TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- create `threat_logs` and `common_logs` tables
- save logs in the appropriate table
- expose `get_threat_logs` and `get_common_logs`
- adjust Flask routes to use the new tables
- document the new design in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d895e2148832a964ecaeafb2e32d2