### PR TITLE
Store ensemble classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ O proxy combina o classificador `Dumi2025/log-anomaly-detection-model-roberta` c
 `YangYang-Research/web-attack-detection` usando uma média ponderada. Ajuste os
 pesos e o limiar pelas variáveis `ENSEMBLE_W_ROBERTA`, `ENSEMBLE_W_ATTACK` e
 `ENSEMBLE_THRESHOLD` no `.env`.
+O resultado desse ensemble define o campo `is_attack` salvo no banco de dados,
+distinguindo entre *Logs de Ameaças* e *Logs Comuns*.
 
 ## Banco de dados
 

--- a/app/db.py
+++ b/app/db.py
@@ -43,13 +43,28 @@ def init_db():
 
 
 def save_log(
-    interface, data, severity, anomaly, nids, semantic=None, ip=None, ip_info=None
+    interface,
+    data,
+    severity,
+    anomaly,
+    nids,
+    semantic=None,
+    ip=None,
+    ip_info=None,
+    *,
+    is_attack=None,
 ):
-    """Persist the log in the appropriate table based on attack classification."""
+    """Persist the log in the appropriate table based on attack classification.
+
+    The ``is_attack`` flag can be provided directly. When omitted, the value is
+    derived from the NIDS result as in previous versions for backward
+    compatibility.
+    """
     if conn is None:
         return None
 
-    is_attack = _is_attack_entry(nids)
+    if is_attack is None:
+        is_attack = _is_attack_entry(nids)
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute(
             """

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -77,6 +77,7 @@ def analyze_request() -> dict:
         ip_info = fetch_ip_info(ip)
     result = detector.analyze(full_text)
     category = result["nids"].get("majority", result["nids"]["label"])
+    is_attack = str(result.get("ensemble", {}).get("label", "normal")).lower() != "normal"
     logger.info(
         "Detection result - severity: %s, anomaly: %s, nids: %s",
         result["severity"]["label"],
@@ -92,6 +93,7 @@ def analyze_request() -> dict:
         result["semantic"],
         ip=ip,
         ip_info=ip_info,
+        is_attack=is_attack,
     )
     created_at = time.strftime("%Y-%m-%d %H:%M:%S")
     log_id = None
@@ -113,7 +115,7 @@ def analyze_request() -> dict:
             "anomaly": result["anomaly"],
             "nids": result["nids"],
             "category": category,
-            "is_attack": _is_attack(category),
+            "is_attack": is_attack,
             "semantic": result["semantic"],
             "ensemble": result.get("ensemble"),
             "intensity": result["intensity"],
@@ -131,7 +133,7 @@ def analyze_request() -> dict:
             "anomaly": result["anomaly"],
             "nids": result["nids"],
             "category": category,
-            "is_attack": _is_attack(category),
+            "is_attack": is_attack,
             "semantic": result["semantic"],
             "ensemble": result.get("ensemble"),
             "intensity": result["intensity"],


### PR DESCRIPTION
## Summary
- allow `save_log()` to accept an explicit `is_attack` flag
- persist ensemble decision when saving logs
- document that `is_attack` is derived from the ensemble

## Testing
- `pytest -q pentest/test_structure.py`
- `pytest -q pentest/test_security.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pytest -q pentest/test_intensity.py`
- `pytest -q pentest/test_attacks.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686e94843a58832abc07024bc8e05660