### PR TITLE
Fix threat log listing

### DIFF
--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div id="logs-app">
-  <h1 class="display-5 mb-4 text-center">Logs de Ameaças</h1>
+  <h1 class="display-5 mb-4 text-center">{{ title }}</h1>
   <div class="card">
     <div class="card-body p-0">
       <div class="table-responsive">
@@ -39,6 +39,7 @@
 let logsPage = {{ page }};
 let logsData = [];
 let logsEvt = null;
+let logsType = '{{ page_type }}';
 
 function severityClass(label) {
     if (!label) return '';
@@ -84,13 +85,13 @@ function renderLogs() {
 
 async function fetchLogs(page) {
     if (page < 1) return;
-    const res = await fetch(`/api/logs?page=${page}`);
+    const res = await fetch(`/api/logs?page=${page}&type=${logsType}`);
     logsData = await res.json();
     logsPage = page;
     renderLogs();
     if (logsEvt) logsEvt.close();
     if (page === 1) {
-        logsEvt = new EventSource('/stream/logs');
+        logsEvt = new EventSource(`/stream/logs?type=${logsType}`);
         logsEvt.onmessage = (e) => {
             const log = JSON.parse(e.data);
             logsData.unshift(log);

--- a/pentest/conftest.py
+++ b/pentest/conftest.py
@@ -77,7 +77,7 @@ def client(monkeypatch):
     logs = []
     blocked = []
 
-    def save_log(interface, data, severity, anomaly, nids, semantic=None, ip=None, ip_info=None):
+    def save_log(interface, data, severity, anomaly, nids, semantic=None, ip=None, ip_info=None, is_attack=False):
         entry = {
             "id": len(logs) + 1,
             "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
## Summary
- filter /api/logs and /stream/logs by type=threat/common
- pass page_type to template so UI can request correct data
- update JavaScript to use the new parameter
- adjust tests for new save_log signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eaedf1b2c832aa687c68eb9239408