### PR TITLE
Log all request paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Este projeto adiciona uma camada de segurança ao [Nginx Unit](https://unit.ngin
 - A categoria do tráfego é determinada pelo modelo configurado em `NIDS_MODELS`.
 - Script interativo (`python -m app.menu`) para iniciar/parar o proxy e o painel, além de selecionar CPU ou GPU para inferência.
 - Classificação de ataques realizada apenas por modelos de linguagem, sem regex.
-- Requisições para `/favicon.ico`, `/logs` e `/common-logs` só são salvas quando
-  classificadas como anomalias.
+- Todas as requisições, incluindo para `/favicon.ico`, `/logs` e `/common-logs`,
+  são registradas normalmente.
 
 ## Instalação
 

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -28,9 +28,9 @@ detector = Detector()
 
 app = Flask(__name__)
 
-# Certain paths generate a lot of noise in the logs. They are still
-# analysed but only stored when flagged as anomalies.
-SKIP_NON_ANOMALY_PATHS = {"/favicon.ico", "/logs", "/common-logs"}
+# Paths that should be ignored unless flagged as anomalies.  Keeping the
+# constant for future use, but no paths are currently skipped.
+SKIP_NON_ANOMALY_PATHS: set[str] = set()
 
 db.init_db()
 


### PR DESCRIPTION
## Summary
- store `/favicon.ico`, `/logs` and `/common-logs` requests like any other
- note in the README that these paths are logged

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec8a06d94832aa715be2b026c89f2