### PR TITLE
Fix ab test port conflict

### DIFF
--- a/pentest/test_ab.py
+++ b/pentest/test_ab.py
@@ -13,13 +13,15 @@ class Handler(http.server.BaseHTTPRequestHandler):
         pass
 
 def test_ab_basic():
-    server = http.server.HTTPServer(('127.0.0.1', 8080), Handler)
+    server = http.server.HTTPServer(('127.0.0.1', 0), Handler)
     thread = threading.Thread(target=server.serve_forever)
     thread.daemon = True
     thread.start()
     time.sleep(0.5)
     try:
-        result = subprocess.run(['ab', '-n', '5', 'http://127.0.0.1:8080/'],
+        port = server.server_address[1]
+        url = f'http://127.0.0.1:{port}/'
+        result = subprocess.run(['ab', '-n', '5', url],
                                 capture_output=True, text=True, timeout=10)
         assert result.returncode == 0
         assert 'Requests per second' in result.stdout


### PR DESCRIPTION
## Summary
- use an OS-assigned port in `test_ab.py` to avoid clashes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ecdde89ec832aa2cc0ca1e0f367d2